### PR TITLE
Fix link to English help files and correct punctuation

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 Welcome to the [OWASP ZAP](OWASP Zed Attack Proxy) (ZAP) User Guide.
 
-This is available both as context sensitive help within ZAP and online here in the [wiki](https://github.com/zaproxy/zap-core-help/wiki)
+This is available both as context sensitive help within ZAP and online here in the [wiki](https://github.com/zaproxy/zap-core-help/wiki).
 
-The English help files are under the [/src/help/zaphelp](https://github.com/psiinon/zap-core-help/tree/master/src/help/zaphelp) directory.
+The English help files are under the [/src/help/zaphelp](https://github.com/zaproxy/zap-core-help/tree/master/src/help/zaphelp) directory.
 
-You can help translate those pages into other languages via the [OWASP ZAP Help Crowdin project](https://crowdin.com/project/owasp-zap-help)
+You can help translate those pages into other languages via the [OWASP ZAP Help Crowdin project](https://crowdin.com/project/owasp-zap-help).


### PR DESCRIPTION
Fix link to English help files to point to the canonical repo rather
than a fork. Also add missing periods to the sentences.