### PR TITLE
include instructions around where to find the CLI

### DIFF
--- a/src/help/zaphelp/contents/cmdline.html
+++ b/src/help/zaphelp/contents/cmdline.html
@@ -9,6 +9,20 @@ Command Line
 <BODY BGCOLOR="#ffffff">
 <H1>Command Line</H1>
 
+To run ZAP via the command line, you will need to locate the ZAP startup script.<br/>
+<strong>Windows:</strong><br/>
+<pre>C:\Program Files (x86)\OWASP\Zed Attack Proxy\zap.bat</pre>
+<strong>Mac:</strong><br/>
+<pre>/Applications/OWASP\ ZAP.app/Contents/Java/zap.sh</pre>
+<strong>Linux:</strong><br/>
+<code>zap.sh</code> will be below the directory where ZAP was installed.
+<br/><br/>
+Alternatively, you can run the JAR file directly:<br/>
+<pre>java -jar zap.jar</pre>
+All options below can be passed to any of these.
+
+<H2>Options</H2>
+
 ZAP supports the following command line options:
 
 <table>
@@ -35,22 +49,22 @@ ZAP supports the following command line options:
 <tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td>-last_scan_report &lt;path&gt;</td><td>Generate the 'Last Scan Report' into the specified path</td></tr>
 </table>
 <br>
-The options '-session' and '-newsession' are mutually exclusive. An error will be shown and ZAP exit (if not in GUI) when both options are set.
+The options <code>-session</code> and <code>-newsession</code> are mutually exclusive. An error will be shown and ZAP exit (if not in GUI) when both options are set.
 <br>
-Relative paths to session file are resolved against the "session" directory located in ZAP's home directory (default or specified with -dir option).
+Relative paths to session file are resolved against the "session" directory located in ZAP's home directory (default or specified with <code>-dir</code> option).
 <br/>
 Configuration keys should be specified using the dot notation based their location in the XML of the configuration file, eg:<br/>
-<pre>-config api.key=12345 -config connection.timeoutInSecs=60</pre>  
+<pre>&lt;zap-script&gt; -config api.key=12345 -config connection.timeoutInSecs=60</pre>
 Note that add-ons can add extra command line options.
 
 <p>
 Examples:
 	<ul>
 		<li>Start ZAP in 'daemon' mode with a new session created at a given path:
-			<pre>-daemon -newsession session</pre>
+			<pre>&lt;zap-script&gt; -daemon -newsession session</pre>
 		</li>
 		<li>Create a report of the last scan of an existing session and exit ZAP once finished:
-			<pre>-last_scan_report /path/to/save/report.xml -session /path/to/existing/session -cmd</pre>
+			<pre>&lt;zap-script&gt; -last_scan_report /full/path/to/save/report.xml -session /full/path/to/existing/session -cmd</pre>
 		</li>
 	</ul>
 


### PR DESCRIPTION
Also, just because I wasn't sure where else to write them:
- I wanted to update the [HelpAddonsQuickstartCmdline](https://github.com/zaproxy/zap-core-help/wiki/HelpAddonsQuickstartCmdline) page, but couldn't find the file in the repository...am I missing something?
- Would you consider switching the documentation to Markdown? Seems like it would make the documentation source easier to read, and thus to contribute to.
- Would you consider enabling the Issues on this repository? I've come across some documentation-specific issues/suggestions (i.e. the bullets above), and might be nice to have them co-located here, rather than cluttering the primary repository.

Let me know where I should post these to continue the conversation. Thanks!
