### PR TITLE
Update Dynamic SSL Certificates page with code change for client certs

### DIFF
--- a/src/help/zaphelp/contents/ui/dialogs/options/dynsslcert.html
+++ b/src/help/zaphelp/contents/ui/dialogs/options/dynsslcert.html
@@ -160,7 +160,7 @@ And yes, that example will work - its the Superfish certificate!
 </p>
 <p>
 	Every dynamically generated certificate is valid for 1000 days.<br>
-	Every dynamically generated certificate is 1024 bit strong (RSA with SHA1).<br>
+	Every dynamically generated certificate is 2048 bit strong (RSA with SHA1).<br>
 	Every dynamically generated certificate has a random serial number. 
 	Every dynamically generated certificate consists of the following identifiers:
 </p>


### PR DESCRIPTION
Change the key size from 1024 to 2048 to match the one used in the code.
Change done in zaproxy/zaproxy#1690.