### PR TITLE
Core Help - Alerts Topic Updates

### DIFF
--- a/src/help/zaphelp/contents/start/concepts/alerts.html
+++ b/src/help/zaphelp/contents/start/concepts/alerts.html
@@ -23,9 +23,9 @@ Alerts are shown in the UI with a flag indicating the risk:
 </table>
 
 <p>
-Alerts can be raised either via <a href="ascan.html">active scanning</a> or manually using the
-<a href="../../ui/dialogs/addalert.html">Add Alert dialog</a>.<br/>
-This dialog also allows you to change alerts.
+Alerts can be raised by various ZAP components, including but not limited to: <a href="ascan.html">active scanning</a>, <a href="pscan.html">passive scanning</a>, 
+scripts, by addons (extensions), or manually using the <a href="../../ui/dialogs/addalert.html">Add Alert dialog</a> 
+(which also allows you to update or change alert details/information).
 </p>
 <p>
 Alerts are flagged in the <a href="../../ui/tabs/history.html">History tab</a> with a flag which indicates

--- a/src/help/zaphelp/contents/ui/tabs/alerts.html
+++ b/src/help/zaphelp/contents/ui/tabs/alerts.html
@@ -11,16 +11,14 @@ Alerts tab
 
 <p>
 The Alerts tab show the <a href="../../start/concepts/alerts.html">Alerts</a> 
-that have been raised in this session.<br/>
+that have been raised in this session. 
 The alerts are displayed in a tree in risk order in the left hand pane, and each
-node of the tree shows the total number of alerts underneath it.<br/>
-Selecting an alert with one click will display it in the right hand pane.<br/>
-Double clicking an alert will display the <a href="../dialogs/addalert.html">Add Alert</a> 
-dialog which will allow you to change the alert details.
+node of the tree shows the total number of alerts underneath it.
 </p>
 <p>
-Alerts can either be raised by <a href="../../start/concepts/ascan.html">Automated scanning</a>
-or manually via the <a href="history.html">History tab</a>.
+Selecting an alert with one click will display it in the right hand pane. 
+Double clicking an alert will display the <a href="../dialogs/addalert.html">Add Alert</a> 
+dialog which will allow you to change the alert details.
 </p>
 
 	<H2>Filtering alerts</H2>


### PR DESCRIPTION
HelpStartConceptsAlerts updated to include mention and link to passive
scanning as a source of alerts, as well as mentioning that scripts can
be a source of alerts.
HelpUiTabsAlerts removed redundant paragraph about alert sources, as
it's already covered in the concepts page. (Also cleaned up line breaks
vs paragraphs.)

Fixes zaproxy/zaproxy#2243