### PR TITLE
Correct table's location in Options Display screen

### DIFF
--- a/src/help/zaphelp/contents/ui/dialogs/options/view.html
+++ b/src/help/zaphelp/contents/ui/dialogs/options/view.html
@@ -37,16 +37,16 @@ SimpleDateFormat. After choosing or entering a time stamp format if you press en
 to reflect your choice. If ZAP is unable to use a format you've entered then the example is displayed based 
 on the Default format.
 
-<H3>Font Size</H3>
-The default text size used for the ZAP display. If you set this to -1 then the system default size will be used.<br>
-The 'Font Example' field will show you how large the default text will appear.<br>
-This setting will only take effect when ZAP is restarted.
-
 <table border="1" cellpadding="5">
 <tr> <td> Long &amp; Default </td> <td> yyyy-MM-dd HH:mm:ss </td> </tr>
 <tr> <td> ISO8601 </td> <td> yyyy-MM-dd'T'HH:mm:ssZ </td> </tr>
 <tr> <td> Time Only </td> <td> HH:mm:ss </td> </tr>
 </table>
+
+<H3>Font Size</H3>
+The default text size used for the ZAP display. If you set this to -1 then the system default size will be used.<br>
+The 'Font Example' field will show you how large the default text will appear.<br>
+This setting will only take effect when ZAP is restarted.
 
 <H2>See also</H2>
 <table>


### PR DESCRIPTION
Move the option "Font Size" to be after the output timestamps table,
to have the table immediately after the option "Output Tabs Timestamp
Options".