### PR TITLE
Document database's option Recovery Log

### DIFF
--- a/src/help/zaphelp/contents/ui/dialogs/options/database.html
+++ b/src/help/zaphelp/contents/ui/dialogs/options/database.html
@@ -15,6 +15,10 @@ This screen allows you to configure the database options:
 Allows to compact the database when ZAP is closed, compacting the database 
 ensures a minimal space disk usage but it will also take longer to exit ZAP.
 
+<H3>Recovery Log</H3>
+Controls whether or not database's recovery log is enabled.<br>Improves the performance of the database when disabled but might lead to data loss if ZAP is exited abruptly.<br>
+Note: current session will be unaffected, changes take effect on new and opened sessions.
+
 <H3>Maximum Request Body Size</H3>
 The largest request body size in bytes that ZAP will allow.
 


### PR DESCRIPTION
Change "Options Database screen" page to document the option Recovery
Log.

Part of zaproxy/zaproxy#1958 - Allow to disable database (HSQLDB) log