### PR TITLE
Document spider's option Spider Subtree Only

### DIFF
--- a/src/help/zaphelp/contents/ui/dialogs/spider.html
+++ b/src/help/zaphelp/contents/ui/dialogs/spider.html
@@ -19,6 +19,9 @@ If you select one of the users then the spider will be performed as that user, w
 <br><br>
 If you select 'recurse' then all of the nodes underneath the one selected will also be used to seed the spider.
 <br><br>
+If you select 'Spider Subtree Only' the spider will only access resources that are under the starting point (URI).
+When evaluating if a resource is found within the specified subtree, the spider considers only the scheme, host, port, and path components of the URI.
+<br><br>
 If you select 'Show advanced options' then the following tab will be shown which provide fine grain control over the spider process.
 <br><br>
 Clicking on the 'Reset' button will reset all of the options to their default values. 


### PR DESCRIPTION
Change "Spider dialog" page to document the option Spider Subtree Only.

Part of zaproxy/zaproxy#2274 - Allow to spider just a site's subtree