### PR TITLE
Document some display options

### DIFF
--- a/src/help/zaphelp/contents/ui/dialogs/options/view.html
+++ b/src/help/zaphelp/contents/ui/dialogs/options/view.html
@@ -15,7 +15,34 @@ The Display screen allows you to configure:
 If ZAP processes images.
 
 <H3>Display</H3>
-The layout of the 3 main windows.
+The layout of the 3 main panels.<br>
+The following options are available:
+<ul>
+    <li>Maximise left (Sites) tab - The 'tree' panel containing the Sites tab extends
+        for the full length of the left hand side. This will reduce the amount of
+        space available to the 'information' panel.</li>
+    <li>Maximise bottom (History etc) tabs - The 'information' panel extends for the
+        full length of the bottom. This will reduce the amount of space available to
+        the 'tree' panel.</li>
+    <li>Full Layout - The selected tab takes up the full screen. This is
+        useful when using ZAP on small screens.</li>
+</ul>
+
+<H3>Response Panel Position</H3>
+Allows to configure the position of the Response tab with respect to Request tab.<br>
+The following options are available:
+<ul>
+    <li>Tabs Side by Side - The Request and Response tabs are side by side. This
+        increases the information that can be displayed but means you cannot see both the
+        request and response at the same time.</li>
+    <li>Panels Side by Side - The Request panel is shown to the left of the Response
+        panel. This decreases the information that can be displayed but means you can see both
+        the request and response at the same time.</li>
+    <li>Request Shown Above Response - The Request panel is shown above the Response
+        panel. This decreases the information that can be displayed but means you can see both
+        the request and response at the same time.</li>
+</ul>
+The Response Panel Position option does not apply when the Display option is set to Full Layout.
 
 <H3>Show break buttons</H3>
 The location of the break buttons.

--- a/src/help/zaphelp/contents/ui/tltoolbar.html
+++ b/src/help/zaphelp/contents/ui/tltoolbar.html
@@ -50,7 +50,7 @@ This will reduce the amount of space available to the 'information' window.
 This changes the display so that the 'information' window extends for the full length of the bottom.<br> 
 This will reduce the amount of space available to the 'tree' window.
 
-<H2><img src="../images/expand_full.png" align="bottom" width="16" height="16" />&nbsp; Expand Full</H2>
+<H2><img src="../images/expand_full.png" align="bottom" width="16" height="16" />&nbsp; Full Layout</H2>
 This changes the display so that the selected tab takes up the full screen.<br> 
 This is useful when using ZAP on small screens.
 


### PR DESCRIPTION
Change "Options Display screen" page to document the option Response
Panel Position and document the options available in the Display option.
(Both the options are based on the documentation from the main tool
bar.)
Change "Top Level Toolbar" page to rename the option Expand Full to Full
Layout.

Part of zaproxy/zaproxy#2374 - Unable to change response tab position
without main tool bar
Part of zaproxy/zaproxy#2361 - Rename tool bar option Expand Full to
Full Layout