### PR TITLE
Normalise the case of HTTP

### DIFF
--- a/src/help/zaphelp/contents/start/concepts/authentication.html
+++ b/src/help/zaphelp/contents/start/concepts/authentication.html
@@ -78,7 +78,7 @@
 	</h3>
 	<p>This method allows users to perform the authentication manually
 		(e.g. authenticate in the browser while proxy-ing through ZAP) and
-		then select the corresponding HttpSession. As the actual
+		then select the corresponding HTTP session. As the actual
 		authentication is being performed by you, this method does not support
 		re-authentication in case the webapp logs a user out.
 	</p>

--- a/src/help/zaphelp/contents/start/concepts/concepts.html
+++ b/src/help/zaphelp/contents/start/concepts/concepts.html
@@ -20,7 +20,7 @@ ZAP provides the following features:
 <tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td><a href="contexts.html">Contexts</a></td><td></td></tr>
 <tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td><a href="ddc.html">Data Driven Content</a></td><td></td></tr>
 <tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td><a href="filters.html">Filters</a></td><td></td></tr>
-<tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td><a href="httpsessions.html">Http Sessions</a></td><td></td></tr>
+<tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td><a href="httpsessions.html">HTTP Sessions</a></td><td></td></tr>
 <tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td><a href="intercept.html">Intercepting Proxy</a></td><td></td></tr>
 <tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td><a href="modes.html">Modes</a></td><td></td></tr>
 <tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td><a href="notes.html">Notes</a></td><td></td></tr>

--- a/src/help/zaphelp/contents/start/concepts/httpsessions.html
+++ b/src/help/zaphelp/contents/start/concepts/httpsessions.html
@@ -2,11 +2,11 @@
 <html>
 <head>
 <META HTTP-EQUIV="Content-Type" CONTENT="text/html; charset=utf-8">
-<title>Http Sessions</title>
+<title>HTTP Sessions</title>
 </head>
 <body bgcolor="#ffffff">
-	<h1>Http Sessions</h1>
-	<p>This tool keeps track of the existing Http Sessions on a
+	<h1>HTTP Sessions</h1>
+	<p>This tool keeps track of the existing HTTP Sessions on a
 		particular Site and allows the Zaproxy user to force all requests to
 		be on a particular session. Basically, it allows the user to easily
 		switch between user sessions on a Site and to create a new Session
@@ -31,12 +31,12 @@
 		This tool automatically detects, using the defined session tokens or
 		the automatically detected default session tokens, any HTTP session
 		which exists in the communication. The detected sessions are shown in
-		the <a href="../../ui/tabs/httpsessions.html">Http Sessions Tab</a>.
+		the <a href="../../ui/tabs/httpsessions.html">HTTP Sessions Tab</a>.
 	</p>
 
 	<p>
 		The user can, using the button available on the <a
-			href="../../ui/tabs/httpsessions.html">Http Sessions Tab</a>, create
+			href="../../ui/tabs/httpsessions.html">HTTP Sessions Tab</a>, create
 		a new session without destroying the existing one, or can force one of
 		the sessions as 'active'. When a session is 'active', all the outbound
 		requests sent to the corresponding Site are modified, the session
@@ -46,8 +46,8 @@
 	</p>
 
 	<p>
-		The Http Sessions tool is configured using the <a
-			href="../../ui/dialogs/options/httpsessions.html">Http Sessions
+		The HTTP Sessions tool is configured using the <a
+			href="../../ui/dialogs/options/httpsessions.html">HTTP Sessions
 			Options screen</a>.
 	</p>
 
@@ -55,7 +55,7 @@
 	<table>
 		<tr>
 			<td>&nbsp;&nbsp;&nbsp;&nbsp;</td>
-			<td><a href="../../ui/tabs/httpsessions.html">Http Sessions
+			<td><a href="../../ui/tabs/httpsessions.html">HTTP Sessions
 					tab</a></td>
 			<td></td>
 		</tr>
@@ -75,7 +75,7 @@
 		</tr>
 		<tr>
 			<td>&nbsp;&nbsp;&nbsp;&nbsp;</td>
-			<td><a href="../../ui/dialogs/options/httpsessions.html">Http
+			<td><a href="../../ui/dialogs/options/httpsessions.html">HTTP
 					Sessions Options screen</a></td>
 			<td>for an overview of the tool's Options</td>
 		</tr>

--- a/src/help/zaphelp/contents/start/concepts/sessionManagement.html
+++ b/src/help/zaphelp/contents/start/concepts/sessionManagement.html
@@ -23,7 +23,7 @@
 	<p>
 		In the case of this method the session is being tracked through
 		cookies. Currently, the session tokens that are used are imported from
-		the <a href="httpsessions.html">Http Sessions</a> Extension.
+		the <a href="httpsessions.html">HTTP Sessions</a> Extension.
 	</p>
 
 	<h2>Configured via</h2>

--- a/src/help/zaphelp/contents/ui/dialogs/options/httpsessions.html
+++ b/src/help/zaphelp/contents/ui/dialogs/options/httpsessions.html
@@ -2,13 +2,13 @@
 <HTML>
 <HEAD>
 <META HTTP-EQUIV="Content-Type" CONTENT="text/html; charset=utf-8">
-<TITLE>Options Http Sessions screen</TITLE>
+<TITLE>Options HTTP Sessions screen</TITLE>
 </HEAD>
 <BODY BGCOLOR="#ffffff">
-	<H1>Options Http Sessions screen</H1>
+	<H1>Options HTTP Sessions screen</H1>
 	<p>
 		This screen allows you to configure the <a
-			href="../../../start/concepts/httpsessions.html">Http Sessions
+			href="../../../start/concepts/httpsessions.html">HTTP Sessions
 			Extension's</a> options:
 	</p>
 
@@ -42,13 +42,13 @@
 		</tr>
 		<tr>
 			<td>&nbsp;&nbsp;&nbsp;&nbsp;</td>
-			<td><a href="../../../start/concepts/httpsessions.html">Http
+			<td><a href="../../../start/concepts/httpsessions.html">HTTP
 					Sessions Tool</a></td>
 			<td>for an overview of the Tool</td>
 		</tr>
 		<tr>
 			<td>&nbsp;&nbsp;&nbsp;&nbsp;</td>
-			<td><a href="../../../ui/tabs/httpsessions.html">Http Sessions
+			<td><a href="../../../ui/tabs/httpsessions.html">HTTP Sessions
 					tab</a></td>
 			<td>for an overview of the Tab</td>
 		</tr>

--- a/src/help/zaphelp/contents/ui/tabs/httpsessions.html
+++ b/src/help/zaphelp/contents/ui/tabs/httpsessions.html
@@ -2,10 +2,10 @@
 <html>
 <head>
 <META HTTP-EQUIV="Content-Type" CONTENT="text/html; charset=utf-8">
-<title>Http Sessions tab</title>
+<title>HTTP Sessions tab</title>
 </head>
 <body bgcolor="#ffffff">
-	<h1>Http Sessions tab</h1>
+	<h1>HTTP Sessions tab</h1>
 	<p>
 		This tab shows you the set of identified HTTP sessions for each Site,
 		as detected by the <a href="../../start/concepts/httpsessions.html">HTTP
@@ -68,13 +68,13 @@
 		</tr>
 		<tr>
 			<td>&nbsp;&nbsp;&nbsp;&nbsp;</td>
-			<td><a href="../../start/concepts/httpsessions.html">Http
+			<td><a href="../../start/concepts/httpsessions.html">HTTP
 					Sessions Extension</a></td>
 			<td>for an overview of the extension</td>
 		</tr>
 		<tr>
 			<td>&nbsp;&nbsp;&nbsp;&nbsp;</td>
-			<td><a href="../../ui/dialogs/options/httpsessions.html">Http
+			<td><a href="../../ui/dialogs/options/httpsessions.html">HTTP
 					Sessions Options screen</a></td>
 			<td>for an overview of the extension's Options</td>
 		</tr>

--- a/src/help/zaphelp/contents/ui/tabs/params.html
+++ b/src/help/zaphelp/contents/ui/tabs/params.html
@@ -45,13 +45,13 @@ This will remove the Anti CSRF token flag from the parameter.<br>
 
 <H3>Flag as Session token</H3>
 	This will mark the parameter as a Session token  for the current Site and will notify the
-	<a href="../../start/concepts/httpsessions.html">Http Sessions</a> tool
+	<a href="../../start/concepts/httpsessions.html">HTTP Sessions</a> tool
 	accordingly.
 	<br>
 
 <H3>Unflag as Session token</H3>
 This will unmark the parameter as a Session token for the current site and will notify the
-	<a href="../../start/concepts/httpsessions.html">Http Sessions</a> tool
+	<a href="../../start/concepts/httpsessions.html">HTTP Sessions</a> tool
 	accordingly.
 	<br>
 	

--- a/src/help/zaphelp/toc.xml
+++ b/src/help/zaphelp/toc.xml
@@ -28,7 +28,7 @@
          <tocitem text="Data Driven Content" target="start.concepts.ddc"/>
          <tocitem text="Filters" target="start.concepts.filters"/>
          <tocitem text="Globally Excluded URLs" target="start.concepts.globalexcludeurl"/>
-         <tocitem text="Http Sessions" target="start.concepts.httpsessions"/>
+         <tocitem text="HTTP Sessions" target="start.concepts.httpsessions"/>
          <tocitem text="Intercepting Proxy" target="start.concepts.intercept"/>
          <tocitem text="Modes" target="start.concepts.modes"/>
          <tocitem text="Notes" target="start.concepts.notes"/>
@@ -72,7 +72,7 @@
          <tocitem text="Active Scan" target="ui.tabs.ascan"/>
          <tocitem text="Spider" target="ui.tabs.spider"/>
          <tocitem text="Params" target="ui.tabs.params"/>
-         <tocitem text="Http Sessions" target="ui.tabs.httpsessions"/>
+         <tocitem text="HTTP Sessions" target="ui.tabs.httpsessions"/>
          <tocitem text="Output" target="ui.tabs.output"/>
       </tocitem>
       <tocitem text="The Dialogs" target="ui.dialogs">
@@ -102,7 +102,7 @@
          	<tocitem text="Display" target="ui.dialogs.options.view"/>
          	<tocitem text="Dynamic SSL Certificates" target="ui.dialogs.options.dynsslcert"/>
             <tocitem text="Extensions" target="ui.dialogs.options.ext"/>
-         	<tocitem text="Http Sessions" target="ui.dialogs.options.httpsessions"/>
+         	<tocitem text="HTTP Sessions" target="ui.dialogs.options.httpsessions"/>
             <tocitem text="Global Exclude URL" target="ui.dialogs.options.globalexcludeurl"/>
          	<tocitem text="jvm" target="ui.dialogs.options.jvm"/>
          	<tocitem text="Keyboard" target="ui.dialogs.options.keyboard"/>


### PR DESCRIPTION
Update help pages and TOC to use HTTP instead of Http.

Related to zaproxy/zaproxy#2467 - Normalise the case of HTTP/S