### PR TITLE
Use custom SearchView for proper error handling

### DIFF
--- a/src/help/zaphelp/helpset.hs
+++ b/src/help/zaphelp/helpset.hs
@@ -32,7 +32,7 @@
   <view>
     <name>Search</name>
     <label>Search</label>
-    <type>javax.help.SearchView</type>
+    <type>org.zaproxy.zap.extension.help.ZapSearchView</type>
     <data engine="com.sun.java.help.search.DefaultSearchEngine">
       JavaHelpSearch
     </data>

--- a/src/help/zaphelp_ar_SA/helpset_ar_SA.hs
+++ b/src/help/zaphelp_ar_SA/helpset_ar_SA.hs
@@ -29,7 +29,7 @@
   <view>
     <name>Search</name>
     <label>بحث</label>
-    <type>javax.help.SearchView</type>
+    <type>org.zaproxy.zap.extension.help.ZapSearchView</type>
     <data engine="com.sun.java.help.search.DefaultSearchEngine">
       JavaHelpSearch
     </data>

--- a/src/help/zaphelp_az_AZ/helpset_az_AZ.hs
+++ b/src/help/zaphelp_az_AZ/helpset_az_AZ.hs
@@ -29,7 +29,7 @@
   <view>
     <name>Search</name>
     <label>Axtar</label>
-    <type>javax.help.SearchView</type>
+    <type>org.zaproxy.zap.extension.help.ZapSearchView</type>
     <data engine="com.sun.java.help.search.DefaultSearchEngine">
       JavaHelpSearch
     </data>

--- a/src/help/zaphelp_bs_BA/helpset_bs_BA.hs
+++ b/src/help/zaphelp_bs_BA/helpset_bs_BA.hs
@@ -29,7 +29,7 @@
   <view>
     <name>Search</name>
     <label>Traži</label>
-    <type>javax.help.SearchView</type>
+    <type>org.zaproxy.zap.extension.help.ZapSearchView</type>
     <data engine="com.sun.java.help.search.DefaultSearchEngine">
       JavaHelpSearch
     </data>

--- a/src/help/zaphelp_da_DK/helpset_da_DK.hs
+++ b/src/help/zaphelp_da_DK/helpset_da_DK.hs
@@ -29,7 +29,7 @@
   <view>
     <name>Search</name>
     <label>Søg</label>
-    <type>javax.help.SearchView</type>
+    <type>org.zaproxy.zap.extension.help.ZapSearchView</type>
     <data engine="com.sun.java.help.search.DefaultSearchEngine">
       JavaHelpSearch
     </data>

--- a/src/help/zaphelp_de_DE/helpset_de_DE.hs
+++ b/src/help/zaphelp_de_DE/helpset_de_DE.hs
@@ -29,7 +29,7 @@
   <view>
     <name>Search</name>
     <label>Suche</label>
-    <type>javax.help.SearchView</type>
+    <type>org.zaproxy.zap.extension.help.ZapSearchView</type>
     <data engine="com.sun.java.help.search.DefaultSearchEngine">
       JavaHelpSearch
     </data>

--- a/src/help/zaphelp_el_GR/helpset_el_GR.hs
+++ b/src/help/zaphelp_el_GR/helpset_el_GR.hs
@@ -29,7 +29,7 @@
   <view>
     <name>Search</name>
     <label>Αναζήτηση</label>
-    <type>javax.help.SearchView</type>
+    <type>org.zaproxy.zap.extension.help.ZapSearchView</type>
     <data engine="com.sun.java.help.search.DefaultSearchEngine">
       JavaHelpSearch
     </data>

--- a/src/help/zaphelp_es_ES/helpset_es_ES.hs
+++ b/src/help/zaphelp_es_ES/helpset_es_ES.hs
@@ -29,7 +29,7 @@
   <view>
     <name>Search</name>
     <label>Buscar</label>
-    <type>javax.help.SearchView</type>
+    <type>org.zaproxy.zap.extension.help.ZapSearchView</type>
     <data engine="com.sun.java.help.search.DefaultSearchEngine">
       JavaHelpSearch
     </data>

--- a/src/help/zaphelp_fa_IR/helpset_fa_IR.hs
+++ b/src/help/zaphelp_fa_IR/helpset_fa_IR.hs
@@ -29,7 +29,7 @@
   <view>
     <name>Search</name>
     <label>جستجو</label>
-    <type>javax.help.SearchView</type>
+    <type>org.zaproxy.zap.extension.help.ZapSearchView</type>
     <data engine="com.sun.java.help.search.DefaultSearchEngine">
       JavaHelpSearch
     </data>

--- a/src/help/zaphelp_fil_PH/helpset_fil_PH.hs
+++ b/src/help/zaphelp_fil_PH/helpset_fil_PH.hs
@@ -29,7 +29,7 @@
   <view>
     <name>Search</name>
     <label>Search</label>
-    <type>javax.help.SearchView</type>
+    <type>org.zaproxy.zap.extension.help.ZapSearchView</type>
     <data engine="com.sun.java.help.search.DefaultSearchEngine">
       JavaHelpSearch
     </data>

--- a/src/help/zaphelp_fr_FR/helpset_fr_FR.hs
+++ b/src/help/zaphelp_fr_FR/helpset_fr_FR.hs
@@ -29,7 +29,7 @@
   <view>
     <name>Search</name>
     <label>Rechercher</label>
-    <type>javax.help.SearchView</type>
+    <type>org.zaproxy.zap.extension.help.ZapSearchView</type>
     <data engine="com.sun.java.help.search.DefaultSearchEngine">
       JavaHelpSearch
     </data>

--- a/src/help/zaphelp_hi_IN/helpset_hi_IN.hs
+++ b/src/help/zaphelp_hi_IN/helpset_hi_IN.hs
@@ -29,7 +29,7 @@
   <view>
     <name>Search</name>
     <label>Search</label>
-    <type>javax.help.SearchView</type>
+    <type>org.zaproxy.zap.extension.help.ZapSearchView</type>
     <data engine="com.sun.java.help.search.DefaultSearchEngine">
       JavaHelpSearch
     </data>

--- a/src/help/zaphelp_hr_HR/helpset_hr_HR.hs
+++ b/src/help/zaphelp_hr_HR/helpset_hr_HR.hs
@@ -29,7 +29,7 @@
   <view>
     <name>Search</name>
     <label>Search</label>
-    <type>javax.help.SearchView</type>
+    <type>org.zaproxy.zap.extension.help.ZapSearchView</type>
     <data engine="com.sun.java.help.search.DefaultSearchEngine">
       JavaHelpSearch
     </data>

--- a/src/help/zaphelp_hu_HU/helpset_hu_HU.hs
+++ b/src/help/zaphelp_hu_HU/helpset_hu_HU.hs
@@ -29,7 +29,7 @@
   <view>
     <name>Search</name>
     <label>Search</label>
-    <type>javax.help.SearchView</type>
+    <type>org.zaproxy.zap.extension.help.ZapSearchView</type>
     <data engine="com.sun.java.help.search.DefaultSearchEngine">
       JavaHelpSearch
     </data>

--- a/src/help/zaphelp_id_ID/helpset_id_ID.hs
+++ b/src/help/zaphelp_id_ID/helpset_id_ID.hs
@@ -29,7 +29,7 @@
   <view>
     <name>Search</name>
     <label>Telusuri</label>
-    <type>javax.help.SearchView</type>
+    <type>org.zaproxy.zap.extension.help.ZapSearchView</type>
     <data engine="com.sun.java.help.search.DefaultSearchEngine">
       JavaHelpSearch
     </data>

--- a/src/help/zaphelp_it_IT/helpset_it_IT.hs
+++ b/src/help/zaphelp_it_IT/helpset_it_IT.hs
@@ -29,7 +29,7 @@
   <view>
     <name>Search</name>
     <label>Ricerca</label>
-    <type>javax.help.SearchView</type>
+    <type>org.zaproxy.zap.extension.help.ZapSearchView</type>
     <data engine="com.sun.java.help.search.DefaultSearchEngine">
       JavaHelpSearch
     </data>

--- a/src/help/zaphelp_ja_JP/helpset_ja_JP.hs
+++ b/src/help/zaphelp_ja_JP/helpset_ja_JP.hs
@@ -29,7 +29,7 @@
   <view>
     <name>Search</name>
     <label>検索</label>
-    <type>javax.help.SearchView</type>
+    <type>org.zaproxy.zap.extension.help.ZapSearchView</type>
     <data engine="com.sun.java.help.search.DefaultSearchEngine">
       JavaHelpSearch
     </data>

--- a/src/help/zaphelp_ko_KR/helpset_ko_KR.hs
+++ b/src/help/zaphelp_ko_KR/helpset_ko_KR.hs
@@ -29,7 +29,7 @@
   <view>
     <name>Search</name>
     <label>Search</label>
-    <type>javax.help.SearchView</type>
+    <type>org.zaproxy.zap.extension.help.ZapSearchView</type>
     <data engine="com.sun.java.help.search.DefaultSearchEngine">
       JavaHelpSearch
     </data>

--- a/src/help/zaphelp_pl_PL/helpset_pl_PL.hs
+++ b/src/help/zaphelp_pl_PL/helpset_pl_PL.hs
@@ -29,7 +29,7 @@
   <view>
     <name>Search</name>
     <label>Szukaj</label>
-    <type>javax.help.SearchView</type>
+    <type>org.zaproxy.zap.extension.help.ZapSearchView</type>
     <data engine="com.sun.java.help.search.DefaultSearchEngine">
       JavaHelpSearch
     </data>

--- a/src/help/zaphelp_pt_BR/helpset_pt_BR.hs
+++ b/src/help/zaphelp_pt_BR/helpset_pt_BR.hs
@@ -29,7 +29,7 @@
   <view>
     <name>Search</name>
     <label>Localizar</label>
-    <type>javax.help.SearchView</type>
+    <type>org.zaproxy.zap.extension.help.ZapSearchView</type>
     <data engine="com.sun.java.help.search.DefaultSearchEngine">
       JavaHelpSearch
     </data>

--- a/src/help/zaphelp_ro_RO/helpset_ro_RO.hs
+++ b/src/help/zaphelp_ro_RO/helpset_ro_RO.hs
@@ -29,7 +29,7 @@
   <view>
     <name>Search</name>
     <label>Search</label>
-    <type>javax.help.SearchView</type>
+    <type>org.zaproxy.zap.extension.help.ZapSearchView</type>
     <data engine="com.sun.java.help.search.DefaultSearchEngine">
       JavaHelpSearch
     </data>

--- a/src/help/zaphelp_ru_RU/helpset_ru_RU.hs
+++ b/src/help/zaphelp_ru_RU/helpset_ru_RU.hs
@@ -29,7 +29,7 @@
   <view>
     <name>Search</name>
     <label>Поиск</label>
-    <type>javax.help.SearchView</type>
+    <type>org.zaproxy.zap.extension.help.ZapSearchView</type>
     <data engine="com.sun.java.help.search.DefaultSearchEngine">
       JavaHelpSearch
     </data>

--- a/src/help/zaphelp_si_LK/helpset_si_LK.hs
+++ b/src/help/zaphelp_si_LK/helpset_si_LK.hs
@@ -29,7 +29,7 @@
   <view>
     <name>Search</name>
     <label>Search</label>
-    <type>javax.help.SearchView</type>
+    <type>org.zaproxy.zap.extension.help.ZapSearchView</type>
     <data engine="com.sun.java.help.search.DefaultSearchEngine">
       JavaHelpSearch
     </data>

--- a/src/help/zaphelp_sk_SK/helpset_sk_SK.hs
+++ b/src/help/zaphelp_sk_SK/helpset_sk_SK.hs
@@ -29,7 +29,7 @@
   <view>
     <name>Search</name>
     <label>Search</label>
-    <type>javax.help.SearchView</type>
+    <type>org.zaproxy.zap.extension.help.ZapSearchView</type>
     <data engine="com.sun.java.help.search.DefaultSearchEngine">
       JavaHelpSearch
     </data>

--- a/src/help/zaphelp_sl_SI/helpset_sl_SI.hs
+++ b/src/help/zaphelp_sl_SI/helpset_sl_SI.hs
@@ -29,7 +29,7 @@
   <view>
     <name>Search</name>
     <label>Search</label>
-    <type>javax.help.SearchView</type>
+    <type>org.zaproxy.zap.extension.help.ZapSearchView</type>
     <data engine="com.sun.java.help.search.DefaultSearchEngine">
       JavaHelpSearch
     </data>

--- a/src/help/zaphelp_sq_AL/helpset_sq_AL.hs
+++ b/src/help/zaphelp_sq_AL/helpset_sq_AL.hs
@@ -29,7 +29,7 @@
   <view>
     <name>Search</name>
     <label>Search</label>
-    <type>javax.help.SearchView</type>
+    <type>org.zaproxy.zap.extension.help.ZapSearchView</type>
     <data engine="com.sun.java.help.search.DefaultSearchEngine">
       JavaHelpSearch
     </data>

--- a/src/help/zaphelp_sr_CS/helpset_sr_CS.hs
+++ b/src/help/zaphelp_sr_CS/helpset_sr_CS.hs
@@ -29,7 +29,7 @@
   <view>
     <name>Search</name>
     <label>Search</label>
-    <type>javax.help.SearchView</type>
+    <type>org.zaproxy.zap.extension.help.ZapSearchView</type>
     <data engine="com.sun.java.help.search.DefaultSearchEngine">
       JavaHelpSearch
     </data>

--- a/src/help/zaphelp_sr_SP/helpset_sr_SP.hs
+++ b/src/help/zaphelp_sr_SP/helpset_sr_SP.hs
@@ -29,7 +29,7 @@
   <view>
     <name>Search</name>
     <label>Search</label>
-    <type>javax.help.SearchView</type>
+    <type>org.zaproxy.zap.extension.help.ZapSearchView</type>
     <data engine="com.sun.java.help.search.DefaultSearchEngine">
       JavaHelpSearch
     </data>

--- a/src/help/zaphelp_ur_PK/helpset_ur_PK.hs
+++ b/src/help/zaphelp_ur_PK/helpset_ur_PK.hs
@@ -29,7 +29,7 @@
   <view>
     <name>Search</name>
     <label>Search</label>
-    <type>javax.help.SearchView</type>
+    <type>org.zaproxy.zap.extension.help.ZapSearchView</type>
     <data engine="com.sun.java.help.search.DefaultSearchEngine">
       JavaHelpSearch
     </data>

--- a/src/help/zaphelp_zh_CN/helpset_zh_CN.hs
+++ b/src/help/zaphelp_zh_CN/helpset_zh_CN.hs
@@ -29,7 +29,7 @@
   <view>
     <name>Search</name>
     <label>搜索</label>
-    <type>javax.help.SearchView</type>
+    <type>org.zaproxy.zap.extension.help.ZapSearchView</type>
     <data engine="com.sun.java.help.search.DefaultSearchEngine">
       JavaHelpSearch
     </data>


### PR DESCRIPTION
Change helpset files to use as SearchView the class ZapSearchView which
allows to handle search view merge errors more gracefully (i.e. valid
views are still merged and in the end the User Guide shown).

Related to zaproxy/zaproxy#2479 - Show User Guide even if a search view
has errors