### PR TITLE
Add missing entries to Options dialog page

### DIFF
--- a/src/help/zaphelp/contents/ui/dialogs/options/options.html
+++ b/src/help/zaphelp/contents/ui/dialogs/options/options.html
@@ -23,8 +23,12 @@ It include the following screens:
 <tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td><a href="database.html">Database</a></td><td></td></tr>
 <tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td><a href="view.html">Display</a></td><td></td></tr>
 <tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td><a href="dynsslcert.html">Dynamic SSL Certificate</a></td><td></td></tr>
+<tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td><a href="ext.html">Extensions</a></td><td></td></tr>
+<tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td><a href="globalexcludeurl.html">Global Exclude URL</a></td><td></td></tr>
+<tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td><a href="httpsessions.html">HTTP Sessions</a></td><td></td></tr>
 <tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td><a href="jvm.html">JVM</a></td><td></td></tr>
 <tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td><a href="keyboard.html">Keyboard</a></td><td></td></tr>
+<tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td><a href="language.html">Language</a></td><td></td></tr>
 <tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td><a href="localproxy.html">Local Proxy</a></td><td></td></tr>
 <tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td><a href="pscanrules.html">Passive Scan Rules</a></td><td></td></tr>
 <tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td><a href="pscan.html">Passive Scan Tags</a></td><td></td></tr>

--- a/src/help/zaphelp/toc.xml
+++ b/src/help/zaphelp/toc.xml
@@ -103,9 +103,9 @@
          	<tocitem text="Display" target="ui.dialogs.options.view"/>
          	<tocitem text="Dynamic SSL Certificates" target="ui.dialogs.options.dynsslcert"/>
             <tocitem text="Extensions" target="ui.dialogs.options.ext"/>
-         	<tocitem text="HTTP Sessions" target="ui.dialogs.options.httpsessions"/>
             <tocitem text="Global Exclude URL" target="ui.dialogs.options.globalexcludeurl"/>
-         	<tocitem text="jvm" target="ui.dialogs.options.jvm"/>
+         	<tocitem text="HTTP Sessions" target="ui.dialogs.options.httpsessions"/>
+         	<tocitem text="JVM" target="ui.dialogs.options.jvm"/>
          	<tocitem text="Keyboard" target="ui.dialogs.options.keyboard"/>
          	<tocitem text="Language" target="ui.dialogs.options.language"/>
          	<tocitem text="Local Proxy" target="ui.dialogs.options.localproxy"/>


### PR DESCRIPTION
Add the missing entries Extensions, Global Exclude URL, HTTP Sessions
and Language to "Options dialog" page.
Change the options' entry JVM to all upper case in TOC file and correct
the (alphabetic) ordering of the entries Global Exclude URL and HTTP
Sessions.