### PR TITLE
Document option Show (local) CONNECT requests

### DIFF
--- a/src/help/zaphelp/contents/ui/dialogs/options/view.html
+++ b/src/help/zaphelp/contents/ui/dialogs/options/view.html
@@ -14,6 +14,12 @@ The Display screen allows you to configure:
 <H3>Images</H3>
 If ZAP processes images.
 
+<H3>Show (local) CONNECT requests</H3>
+If the HTTP CONNECT requests received by the <a href="localproxy.html">Local Proxy</a> should be persisted in the current
+<a href="../../tlmenu/file.html">session</a> and shown in the <a href="../../tabs/history.html">History tab</a>. The default is
+to not show those requests, they happen frequently (in preparation for TLS/SSL, WebSocket... connections) and, unless inspecting
+the behaviour of the client application, are not (usually) of much interest.
+
 <H3>Display</H3>
 The layout of the 3 main panels.<br>
 The following options are available:


### PR DESCRIPTION
Change "Options Display screen" page to document the option Show (local)
CONNECT requests.

Part of zaproxy/zaproxy#2494 - ZAP Proxy is not showing the HTTP CONNECT
Request in history tab