### PR TITLE
Correct meaning of chart's option value

### DIFF
--- a/src/help/zaphelp/contents/ui/dialogs/options/ascan.html
+++ b/src/help/zaphelp/contents/ui/dialogs/options/ascan.html
@@ -51,7 +51,8 @@ Attack <a href="../../../start/concepts/modes.html">mode</a>.
 
 <H3>Max progress chart in mins</H3>
 The maximum time in minutes for which response codes will be charted in the
-<a href="../scanprogress.html">Scan Progress dialog</a>, with zero meaning no limit.
+<a href="../scanprogress.html">Scan Progress dialog</a>.<br>
+To disable the chart the option should be set to zero minutes.
 
 <H2>See also</H2>
 <table>


### PR DESCRIPTION
Change "Options Active Scan screen" page to correct the meaning of zero
value for the option "Max progress chart in mins", when set to zero the
chart is disabled.