### PR TITLE
Add note about pending removal of Filters

### DIFF
--- a/src/help/zaphelp/contents/start/concepts/filters.html
+++ b/src/help/zaphelp/contents/start/concepts/filters.html
@@ -9,10 +9,13 @@ Filters
 <BODY BGCOLOR="#ffffff">
 <H1>Filters</H1>
 <p>
+<strong>NOTE: Filters have in effect been replaced by scripts which are more powerful and flexible.<br>
+Filters will be removed in a future version of ZAP.</strong>
+</p>
+<p>
 Filters add extra features that can be applied to every request and response.<br/>
 By default no filters are initially enabled. Enabling all of the filters may
-slow down the proxy.<br/>
-Future versions of the ZAP User Guide will document the default filters in detail.<br/>
+slow down the proxy.
 </p>
 <p>
 Filters are configured via the  <a href="../../ui/dialogs/filter.html">Filters dialog</a>.

--- a/src/help/zaphelp/contents/ui/dialogs/filter.html
+++ b/src/help/zaphelp/contents/ui/dialogs/filter.html
@@ -9,6 +9,10 @@ Filter dialog
 <BODY BGCOLOR="#ffffff">
 <H1>Filter dialog</H1>
 <p>
+<strong>NOTE: Filters have in effect been replaced by scripts which are more powerful and flexible.<br>
+Filters will be removed in a future version of ZAP.</strong>
+</p>
+<p>
 This allows you to set <a href="../../start/concepts/filters.html">filters</a> that are applied to requests and responses.
 </p>
 The following filters are supported by default.


### PR DESCRIPTION
Change "Filters" and "Filter dialog" pages to add a note (based on text
shown in UI) that mentions that the filters have been replaced by
scripts and will be removed in a future version of ZAP.