### PR TITLE
Remove references to menus that no longer exist

### DIFF
--- a/src/help/zaphelp/contents/start/concepts/authentication.html
+++ b/src/help/zaphelp/contents/start/concepts/authentication.html
@@ -153,7 +153,7 @@
     	select it, open the Response View and select the text you wish to define as the indicator using
     	the mouse and select the Flag as Context... Logged in indicator right-click menu option.</li>
     	<li>define as many users as you need in the Session Properties -> Users section.</li>
-    	<li>after this step, various actions are available in ZAP. For example, you now have a new right click option: Attack -> Spider Context As User. Or, using the Forced User Mode, you can force all the interactions that go through ZAP for a given Context to be from the perspective of a User. The User Forced Mode is enabled via the previous-to-last button in the toolbar (the one with the user and the lock) and is configured via Session Properties -> Forced User Mode.</li>
+    	<li>after this step, various actions are available in ZAP. For example, you can now select the user in <a href="../../ui/dialogs/spider.html">Spider dialogue</a>. Or, using the Forced User Mode, you can force all the interactions that go through ZAP for a given Context to be from the perspective of a User. The User Forced Mode is enabled via the previous-to-last button in the toolbar (the one with the user and the lock) and is configured via Session Properties -> Forced User Mode.</li>
 	</ol>
 	
 	Most of the steps above apply as well for other authentication methods. The only things that change when trying

--- a/src/help/zaphelp/contents/start/concepts/spider.html
+++ b/src/help/zaphelp/contents/start/concepts/spider.html
@@ -14,22 +14,7 @@
 		the process continues recursively as long as new resources are found.
 	</p>
 
-	<p>There are 4 methods of starting the Spider, differentiated by the
-		seed list with which it starts:</p>
-	<ul>
-		<li>Spider Site - The seed list contains all the existing URIs
-			already found for the selected site.</li>
-		<li>Spider Subtree - The seed list contains all the existing URIs
-			already found and present in the subtree of the selected node.</li>
-		<li>Spider URL - The seed list contains only the URI
-			corresponding to the selected node (in the Site Tree).</li>
-		<li>Spider all in Scope - The seed list contains all the URIs the
-			user has selected as being 'In Scope'.</li>
-		<li>Spider all in Context... - The seed list contains all the URIs
-			user has selected as being in the selected context.</li>
-	</ul>
-	<i>More details can be found below, in the "Accessed via" section </i>
-
+	<p>The Spider can configured and started using the <a href="../../ui/dialogs/spider.html">Spider dialogue</a>.</p>
 
 	<p>During the processing of an URL, the Spider makes a request to
 		fetch the resource and then parses the response, identifying

--- a/src/help/zaphelp/contents/ui/tabs/search.html
+++ b/src/help/zaphelp/contents/ui/tabs/search.html
@@ -33,20 +33,14 @@ Right clicking on a node will bring up a menu which will allow you to:
 
 <H3>Attack</H3>
 The Attack menu has the following submenus:
-<H4>Active Scan Site</H4>
-This will initiate an 
-<a href="../../start/concepts/ascan.html">active scan</a> of the whole of the site containing the selected node.<br/>
-The <a href="ascan.html">Active Scan tab</a> will be display and will show the progress of the scan.<br/>
 
-<H4>Active Scan Node</H4>
-This will initiate an 
-<a href="../../start/concepts/ascan.html">active scan</a> of just the node selected.<br/>
-The <a href="ascan.html">Active Scan tab</a> will be display and will show the progress of the scan.<br/>
+<H4>Active Scan...</H4>
+This will launch the <a href="../dialogs/advascan.html">Active Scan dialog</a> which allows you to initiate an 
+<a href="../../start/concepts/ascan.html">active scan</a> with the starting point set to the request you selected.<br/>
 
-<H4>Spider Site</H4>
-This will initiate a 
-<a href="../../start/concepts/spider.html">spider</a> of the whole of the site containing the selected node.<br/>
-The <a href="spider.html">Spider tab</a> will be display and will show the progress of the scan.<br/>
+<H4>Spider...</H4>
+This will launch the <a href="../dialogs/spider.html">Spider dialog</a> which allows you to initiate the 
+<a href="../../start/concepts/spider.html">spider</a> with the starting point set to the request you selected.<br/>
 
 <H3>Include in Context</H3>
 This menu allows you to include the selected nodes and all of their subordinates in the specified


### PR DESCRIPTION
Change "Authentication", "Search" and "Spider" pages to remove
references to attack menu items that no longer exist (e.g. "Spider
Site"), either by replacing with new menu items or forwarding to
existing dialogues (Active Scan or Spider).
  ---
Reported in OWASP IRC channel.