### PR TITLE
Correct the name of a main tool bar option

### DIFF
--- a/src/help/zaphelp/contents/ui/tltoolbar.html
+++ b/src/help/zaphelp/contents/ui/tltoolbar.html
@@ -128,7 +128,7 @@ It also allows you to uninstall add-ons.
 
 <H2><img src="../images/fugue/forcedUserOff.png" align="bottom" width="16" height="16" />&nbsp;/&nbsp;
 <img src="../images/fugue/forcedUserOn.png" align="bottom" width="16" height="16" />&nbsp;
-Force User Mode On / Off</H2>
+Forced User Mode On / Off</H2>
 This switches forced user mode on and off.<br/>
 The button is only enabled when you have defined a forced user for at least one 
 <a href="../start/concepts/contexts.html">context</a>, which can be done via the 


### PR DESCRIPTION
Change "Top Level Toolbar" page to correct the name of a option from
"Force User" to "Forced User".
