### PR TITLE
Document the charset used to read/write scripts

### DIFF
--- a/src/help/zaphelp/contents/ui/dialogs/options/script.html
+++ b/src/help/zaphelp/contents/ui/dialogs/options/script.html
@@ -12,7 +12,7 @@ Options Scripts screen
 This screen allows you to configure the script options:
 </p>
 <H3>Directories</H3>
-<p>A list of directories from which scripts will be loaded.</p>
+<p>A list of directories from which scripts will be loaded. ZAP will read (and write) the scripts using the character encoding UTF-8.</p>
 <p>The scripts must be in subdirectories named after the relevant script type (such as 'active', 'passive', 'proxy' etc) and must have an appropriate extension for the script language used.</p>
 <p>Scripts that cannot be written to will be added to the Templates section.</p>
 <p>The ZAP community scripts repository is a good option to add: <a href="https://github.com/zaproxy/community-scripts">https://github.com/zaproxy/community-scripts</a></p>


### PR DESCRIPTION
Change "Options Scripts screen" page to document the character encoding
used to read/write the scripts.

Fix zaproxy/zaproxy#2781 - Document which character encoding is expected
for ZAP scripts
