### PR TITLE
Tweak Scan Policy page

### DIFF
--- a/src/help/zaphelp/contents/start/concepts/scanpolicy.html
+++ b/src/help/zaphelp/contents/start/concepts/scanpolicy.html
@@ -37,16 +37,10 @@ You can also define as many scan policies as you like - these define exactly whi
 
 </p>
 
-<H2>Accessed via</H2>
+<H2>Configured via</H2>
 <table>
 <tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td>
-<a href="../../ui/tabs/ascan.html">Active Scan tab</a></td><td></td></tr>
-<tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td>
-<a href="../../ui/tabs/sites.html">Sites tab</a></td><td>'Attack/Active Scan site' right click menu item</td></tr>
-<tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td>
-<a href="../../ui/tabs/sites.html">Sites tab</a></td><td>'Attack/Active Scan node' right click menu item</td></tr>
-<tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td>
-<a href="../../ui/tabs/history.html">History tab</a></td><td>'Scan this History' right click menu item</td></tr>
+<a href="../../ui/dialogs/scanpolicymgr.html">Scan Policy Manager Dialog</a></td><td>which allows you to manage the scan policies</td></tr>
 </table>
 
 <H2>See also</H2>
@@ -57,8 +51,6 @@ You can also define as many scan policies as you like - these define exactly whi
 <a href="concepts.html">Features</a></td><td>provided by ZAP</td></tr>
 <tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td>
 <a href="pscan.html">Passive scanning</a></td><td></td></tr>
-<tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td>
-<a href="../../ui/dialogs/scanpolicymgr.html">Scan Policy Manager Dialog</a></td><td>which allows you to manage the scan policies</td></tr>
 <tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td>
 <a href="../checks.html">Scanner Rules</a></td><td>supported by default</td></tr>
 </table>


### PR DESCRIPTION
Replace the section "Accessed via" with "Configured via" and use the
link that was in the "See also" section for the "Scan Policy Manager"
dialog page (the previous links in "Accessed via" section were removed,
they were linking to other functionality).
