### PR TITLE
Remove menu that no longer exists in History tab

### DIFF
--- a/src/help/zaphelp/contents/ui/tabs/history.html
+++ b/src/help/zaphelp/contents/ui/tabs/history.html
@@ -124,10 +124,6 @@ This will bring up the
 <a href="../dialogs/addbreak.html">Add Break Point dialog</a> which allows 
 you to set a break point on that URL.<br/>
 
-<H3>Scan this History</H3>
-This will perform an <a href="../../start/concepts/ascan.html">active scan</a>
-against the URL related to the selected request.
-
 <H3>Alerts for this node</H3>
 If the URL selected has <a href="../../start/concepts/alerts.html">alerts</a> associated with it then 
 they will be listed under this menu.<br>


### PR DESCRIPTION
Change "History tab" page to remove a reference to a context menu item
that no longer exists ("Scan this History").
