### PR TITLE
Add help for new passive scanner option

### DIFF
--- a/src/help/zaphelp/contents/start/concepts/pscan.html
+++ b/src/help/zaphelp/contents/start/concepts/pscan.html
@@ -15,6 +15,10 @@ Scanned is performed in a background thread to ensure that it does not slow down
 of an application.
 </p>
 <p>
+The (main) behaviour of the passive scanner can be configured using the 
+<a href="../../ui/dialogs/options/pscanner.html">Options Passive Scanner Screen</a>.
+</p>
+<p>
 In this release ZAP passive scanning is used for automatically adding <a href="tags.html">tags</a>
 and raising <a href="alerts.html">alerts</a> for potential issues. 
 </p>

--- a/src/help/zaphelp/contents/ui/dialogs/options/options.html
+++ b/src/help/zaphelp/contents/ui/dialogs/options/options.html
@@ -32,6 +32,7 @@ It include the following screens:
 <tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td><a href="localproxy.html">Local Proxy</a></td><td></td></tr>
 <tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td><a href="pscanrules.html">Passive Scan Rules</a></td><td></td></tr>
 <tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td><a href="pscan.html">Passive Scan Tags</a></td><td></td></tr>
+<tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td><a href="pscanner.html">Passive Scanner</a></td><td></td></tr>
 <tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td><a href="script.html">Scripts</a></td><td></td></tr>
 <tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td><a href="search.html">Search</a></td><td></td></tr>
 <tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td><a href="spider.html">Spider</a></td><td></td></tr>

--- a/src/help/zaphelp/contents/ui/dialogs/options/pscanner.html
+++ b/src/help/zaphelp/contents/ui/dialogs/options/pscanner.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 3.2 Final//EN">
+<HTML>
+<HEAD>
+<META HTTP-EQUIV="Content-Type" CONTENT="text/html; charset=utf-8">
+<TITLE>Options Passive Scanner Screen</TITLE>
+</HEAD>
+<BODY BGCOLOR="#ffffff">
+	<H1>Options Passive Scanner screen</H1>
+	<p>
+		This screen allows you to configure the <a href="../../../start/concepts/pscan.html">passive
+			scanner</a>.
+	<h2>Configuration option explanation</h2>
+	<table border="2">
+		<tr>
+			<th colspan="4">Configuration Options</th>
+		</tr>
+		<tr>
+			<th>Field</th>
+			<th>Details</th>
+			<th>Default</th>
+			<th>Config File</th>
+		</tr>
+		<tr>
+			<td>Scan messages only in scope</td>
+			<td>Sets whether or not the passive scan should be performed only on messages that
+				are <a href="../../../start/concepts/scope.html">in scope</a>.
+			</td>
+			<td align="center">Deselected</td>
+			<td>Key: <code>pscans.scanOnlyInScope</code><br>Values: <code>true</code> or <code>false</code></td>
+		</tr>
+	</table>
+
+	<H2>See also</H2>
+	<table>
+		<tr>
+			<td>&nbsp;&nbsp;&nbsp;&nbsp;</td>
+			<td><a href="../../overview.html">UI Overview</a></td>
+			<td>for an overview of the user interface</td>
+		</tr>
+		<tr>
+			<td>&nbsp;&nbsp;&nbsp;&nbsp;</td>
+			<td><a href="options.html">Options dialogs</a></td>
+			<td>for details of the other Options dialog screens</td>
+		</tr>
+	</table>
+
+</BODY>
+</HTML>

--- a/src/help/zaphelp/index.xml
+++ b/src/help/zaphelp/index.xml
@@ -52,6 +52,7 @@
     <indexitem text="params tab" target="ui.tabs.params" />
     <indexitem text="paros proxy" target="zap.paros" />
     <indexitem text="passive scan" target="start.concepts.pscan" />
+    <indexitem text="passive scanner options" target="ui.dialogs.options.pscan.main" />
     <indexitem text="persist session dialog" target="ui.dialogs.persistsession" />
     <indexitem text="proxy configuration" target="start.proxy" />
     <indexitem text="release 1.0.0" target="zap.releases.1.0.0" />

--- a/src/help/zaphelp/map.jhm
+++ b/src/help/zaphelp/map.jhm
@@ -138,6 +138,7 @@
      	<mapID target="ui.dialogs.options.localproxy" url="contents/ui/dialogs/options/localproxy.html"/>
      	<mapID target="ui.dialogs.options.pscan" url="contents/ui/dialogs/options/pscan.html"/>
      	<mapID target="ui.dialogs.options.pscanrules" url="contents/ui/dialogs/options/pscanrules.html"/>
+     	<mapID target="ui.dialogs.options.pscan.main" url="contents/ui/dialogs/options/pscanner.html"/>
      	<mapID target="ui.dialogs.options.script" url="contents/ui/dialogs/options/script.html" />
      	<mapID target="ui.dialogs.options.search" url="contents/ui/dialogs/options/search.html" />
      	<mapID target="ui.dialogs.options.spider" url="contents/ui/dialogs/options/spider.html"/>

--- a/src/help/zaphelp/toc.xml
+++ b/src/help/zaphelp/toc.xml
@@ -111,6 +111,7 @@
          	<tocitem text="Local Proxy" target="ui.dialogs.options.localproxy"/>
          	<tocitem text="Passive Scan Rules" target="ui.dialogs.options.pscanrules"/>
          	<tocitem text="Passive Scan Tags" target="ui.dialogs.options.pscan"/>
+         	<tocitem text="Passive Scanner" target="ui.dialogs.options.pscan.main"/>
          	<tocitem text="Scripts" target="ui.dialogs.options.script"/>
          	<tocitem text="Search" target="ui.dialogs.options.search"/>
          	<tocitem text="Spider" target="ui.dialogs.options.spider"/>


### PR DESCRIPTION
Document the new passive scanner option that allows to passive scan just
HTTP messages in scope.

Part of zaproxy/zaproxy#3004 - Allow to passive scan just HTTP messages
in scope