### PR TITLE
Tweaks to passive scanner pages

### DIFF
--- a/src/help/zaphelp/contents/start/concepts/pscan.html
+++ b/src/help/zaphelp/contents/start/concepts/pscan.html
@@ -9,9 +9,9 @@ Passive Scan
 <BODY BGCOLOR="#ffffff">
 <H1>Passive Scan</H1>
 <p>
-ZAP passively scans all of the responses from the web application being tested.<br/>
-Passive scanning does not change the responses in any way and is therefore safe to use.<br/>
-Scanned is performed in a background thread to ensure that it does not slow down the exploration
+ZAP by default passively scans all HTTP messages (requests and responses) sent to the web application being tested.<br/>
+Passive scanning does not change the requests nor the responses in any way and is therefore safe to use.<br/>
+Scanning is performed in a background thread to ensure that it does not slow down the exploration
 of an application.
 </p>
 <p>
@@ -19,16 +19,14 @@ The (main) behaviour of the passive scanner can be configured using the
 <a href="../../ui/dialogs/options/pscanner.html">Options Passive Scanner Screen</a>.
 </p>
 <p>
-In this release ZAP passive scanning is used for automatically adding <a href="tags.html">tags</a>
-and raising <a href="alerts.html">alerts</a> for potential issues. 
+Passive scanning can also be used for automatically adding <a href="tags.html">tags</a>
+and raising <a href="alerts.html">alerts</a> for potential issues.<br>
+A set of rules for automatic tagging are provided by default. These can be changed, deleted or
+added to via the <a href="../../ui/dialogs/options/pscan.html">Options Passive Scan Tags screen</a>.
 </p>
 
 <p>
-A set of rules for automatic tagging are provided by default.<br>
-These can be changed, deleted or added to via the <a href="../../ui/dialogs/options/pscan.html">Options Passive Scan Tags screen</a>.<br/>
-</p>
-<p>
-The alerts raised by passive scanning can be configured using the 
+The alerts raised by passive scanners can be configured using the 
 <a href="../../ui/dialogs/options/pscanrules.html">Options Passive Scan Rules screen</a>.<br/>
 </p>
 

--- a/src/help/zaphelp/contents/ui/dialogs/options/pscan.html
+++ b/src/help/zaphelp/contents/ui/dialogs/options/pscan.html
@@ -10,7 +10,7 @@ Options Passive Scan Tags screen
 <H1>Options Passive Scan Tags screen</H1>
 <p>
 This screen allows you to configure the <a href="../../../start/concepts/tags.html">tags</a> 
-that are added by the <a href="../../../start/concepts/pscan.html">passive scaner</a>.
+that are added by the <a href="../../../start/concepts/pscan.html">passive scanner</a>.
 </p>
 You can add, modify and remove the tags via the appropriate buttons.
 


### PR DESCRIPTION
Change page "Passive Scan" concept page to explicitly mention that the
passive scanning scans the whole HTTP message, request and response (not
just the latter), merge paragraphs related to automatic functionality
(tagging and raise of alerts) and other minor tweaks.
Change page "Options Passive Scan Tags screen" to fix a typo.