### PR TITLE
Use HTTPS links whenever possible

### DIFF
--- a/src/help/zaphelp/contents/credits.html
+++ b/src/help/zaphelp/contents/credits.html
@@ -113,7 +113,7 @@ People who have made contributions to ZAP over the years, in alphabetical order:
 </table> 
 
 <H2>ZAP Localization</H2>
-ZAP localization is organized via <a href="http://crowdin.net/project/owasp-zap">http://crowdin.net/project/owasp-zap</a>
+ZAP localization is organized via <a href="https://crowdin.net/project/owasp-zap">https://crowdin.net/project/owasp-zap</a>
 <br><br>
 <table>
 <tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td>Azerbaijanian</td><td>Rashad Aliyev www.microphp.com</td></tr>
@@ -131,16 +131,16 @@ ZAP localization is organized via <a href="http://crowdin.net/project/owasp-zap"
 <tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td>Italian</td><td>Fabio Baroni @Fabiothebest89, Michele Pedrazzoli</td></tr>
 <tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td>Japanese</td><td>Ichiro, Sen UENO, Tetsuji KOYAMA, Motoshige AYAKI, Tsuyufumi WATANABE, @nightyknite, nilfigo, Yuho Kameda</td></tr>
 <tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td>Persian</td><td>Mohsen Mostafa Jokar</td></tr>
-<tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td>Polish</td><td>Lukasz, Patryk Orwat, Adam Ziaja - http://adamziaja.com</td></tr>
+<tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td>Polish</td><td>Lukasz, Patryk Orwat, Adam Ziaja - https://adamziaja.com</td></tr>
 <tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td>Spanish</td><td>Team Iniqua - http://www.iniqua.com, Guifre Ruiz Utges, Leandro Ferrari - Talsoft SRL, Gaspar Modelo Howard, Felipe Zipitria, Fran J. Gomez @ffranz, Alejandro J. Saiz @ocixela, Mauro Gioino, Fernando Raviola, Gerardo Canedo, Jose Bustamante Romero -joseht8@gmai.com, Carmelo Zubeldia</td></tr>
 </table>
 
 <H2>3rd Party Libraries and Files</H2>
 <table>
 <tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td>
-Andiparos</td><td> http://code.google.com/p/andiparos/</td></tr>
+Andiparos</td><td> https://code.google.com/archive/p/andiparos</td></tr>
 <tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td>
-Apache Commons</td><td> http://commons.apache.org/</td></tr>
+Apache Commons</td><td> https://commons.apache.org/</td></tr>
 <tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td>
 BeanShell</td><td> http://www.beanshell.org/</td></tr>
 <tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td>
@@ -150,7 +150,7 @@ HSQLDB</td><td> http://hsqldb.org/</td></tr>
 <tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td>
 JavaHelp</td><td> http://java.sun.com/javase/technologies/desktop/javahelp/</td></tr>
 <tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td>
-OWASP DirBuster</td><td> http://www.owasp.org/index.php/Category:OWASP_DirBuster_Project/</td></tr>
+OWASP DirBuster</td><td> https://www.owasp.org/index.php/Category:OWASP_DirBuster_Project</td></tr>
 <tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td>
 OWASP JBroFuzz</td><td> https://www.owasp.org/index.php/JBroFuzz/</td></tr>
 <tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td>
@@ -158,9 +158,9 @@ Diagona and Fugue Icons</td><td> Some icons are copyright (c) Yusuke Kamiyamane 
 <tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td>
 Crawljax</td><td> https://www.crawljax.com</td></tr>
 <tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td>
-RSyntaxTextArea</td><td> http://fifesoft.com/rsyntaxtextarea/</td></tr>
+RSyntaxTextArea</td><td> https://bobbylight.github.io/RSyntaxTextArea/</td></tr>
 <tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td>
-SwingX</td><td> http://swingx.java.net/</td></tr>
+SwingX</td><td> https://swingx.java.net/</td></tr>
 <tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td>
 HarLib</td><td> http://www.frogthinker.org/projects/harlib</td></tr>
 </table>
@@ -170,7 +170,7 @@ HarLib</td><td> http://www.frogthinker.org/projects/harlib</td></tr>
 <tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td>
 WASC Threat Classification v2.0</td><td>http://projects.webappsec.org/Threat-Classification used for alert titles and descriptions</td></tr>
 <tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td>
-Common Weakness Enumeration</td><td>http://cwe.mitre.org/data/index.html used for alert solutions</td></tr>
+Common Weakness Enumeration</td><td>https://cwe.mitre.org/data/index.html used for alert solutions</td></tr>
 </table>
 
 <H2>Paros</H2>
@@ -182,9 +182,9 @@ Chinotec Technologies Company</td><td> http://www.parosproxy.org</td></tr>
 <H2>Watcher: passive Web-security scanner</H2>
 <table>
 <tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td>
-Casaba</td><td> http://www.casaba.com/</td></tr>
+Casaba</td><td> https://www.casaba.com/</td></tr>
 <tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td>
-Watcher</td><td> http://websecuritytool.codeplex.com/</td></tr>
+Watcher</td><td> https://websecuritytool.codeplex.com/</td></tr>
 </table>
 
 <H2>See also</H2>

--- a/src/help/zaphelp/contents/intro.html
+++ b/src/help/zaphelp/contents/intro.html
@@ -45,7 +45,7 @@ start using ZAP</td></tr>
 <H2>External links</H2>
 <table>
 <tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td><a href="https://www.owasp.org/index.php/ZAP">ZAP homepage</a></td></tr>
-<tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td><a href="http://en.wikipedia.org/wiki/Proxy_server">Wikipedia entry for proxies</a></td></tr>
+<tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td><a href="https://en.wikipedia.org/wiki/Proxy_server">Wikipedia entry for proxies</a></td></tr>
 <tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td><a href="http://www.parosproxy.org">Paros proxy</a></td></tr>
 </table>
 <br/>

--- a/src/help/zaphelp/contents/pentest/pentest.html
+++ b/src/help/zaphelp/contents/pentest/pentest.html
@@ -49,7 +49,7 @@ start using ZAP</td></tr>
 <H2>External Links</H2>
 <table>
 <tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td>
-http://www.owasp.org/index.php/Category:OWASP_Testing_Project</td>
+https://www.owasp.org/index.php/Category:OWASP_Testing_Project</td>
 <td> OWASP Testing Guide</td></tr>
 </table>
 

--- a/src/help/zaphelp/contents/releases/1_1_0.html
+++ b/src/help/zaphelp/contents/releases/1_1_0.html
@@ -15,7 +15,7 @@ The following changes were made in this release:
 
 <H3>OWASP rebranding</H3>
 ZAP has been accepted as an OWASP project.<br>
-Its homepage is now: http://www.owasp.org/index.php/OWASP_Zed_Attack_Proxy_Project
+Its homepage is now: https://www.owasp.org/index.php/OWASP_Zed_Attack_Proxy_Project
 
 <H3>Brute Force</H3>
 The ability to brute force files and directories based on code from the OWASP DirBuster project. <br>

--- a/src/help/zaphelp/contents/releases/2_3_0.html
+++ b/src/help/zaphelp/contents/releases/2_3_0.html
@@ -75,7 +75,7 @@ Many of the release quality active and passive scanning rules have been improved
 <ul>
 <li>A new option to stop individual scan rules without stopping the whole scan</li>
 <li>A new toolbar button that allows you to quickly and easily record Zest scripts.</li>
-<li>A new group for sharing ZAP scripts (<a href="http://groups.google.com/group/zaproxy-scripts">http://groups.google.com/group/zaproxy-scripts</a>) has been created.</li>
+<li>A new group for sharing ZAP scripts (<a href="https://groups.google.com/group/zaproxy-scripts">https://groups.google.com/group/zaproxy-scripts</a>) has been created.</li>
 <li>The ability to spider applications based on source control metadata (SVN and Git) exposed via a web server</li>
 <li>The ability to force breaks from within Proxy scripts</li>
 </ul>

--- a/src/help/zaphelp/contents/start/concepts/authentication.html
+++ b/src/help/zaphelp/contents/start/concepts/authentication.html
@@ -174,8 +174,8 @@
 	<table>
 		<tr>
 			<td>&nbsp;&nbsp;&nbsp;&nbsp;</td>
-			<td><a href="http://youtu.be/cR4gw-cPZOA">Youtube tutorial</a></td>
-			<td>of the Authentication, Session Management and Users Management features of ZAP [external link to http://youtu.be/cR4gw-cPZOA].</td>
+			<td><a href="https://youtu.be/cR4gw-cPZOA">Youtube tutorial</a></td>
+			<td>of the Authentication, Session Management and Users Management features of ZAP [external link to https://youtu.be/cR4gw-cPZOA].</td>
 		</tr>
 		<tr>
 			<td>&nbsp;&nbsp;&nbsp;&nbsp;</td>

--- a/src/help/zaphelp/contents/start/concepts/sessionManagement.html
+++ b/src/help/zaphelp/contents/start/concepts/sessionManagement.html
@@ -47,8 +47,8 @@
 	<table>
 		<tr>
 			<td>&nbsp;&nbsp;&nbsp;&nbsp;</td>
-			<td><a href="http://youtu.be/cR4gw-cPZOA">Youtube tutorial</a></td>
-			<td>of the Authentication, Session Management and Users Management features of ZAP [external link to http://youtu.be/cR4gw-cPZOA].</td>
+			<td><a href="https://youtu.be/cR4gw-cPZOA">Youtube tutorial</a></td>
+			<td>of the Authentication, Session Management and Users Management features of ZAP [external link to https://youtu.be/cR4gw-cPZOA].</td>
 		</tr>
 		<tr>
 			<td>&nbsp;&nbsp;&nbsp;&nbsp;</td>

--- a/src/help/zaphelp/contents/start/concepts/users.html
+++ b/src/help/zaphelp/contents/start/concepts/users.html
@@ -52,8 +52,8 @@
 	<table>
 		<tr>
 			<td>&nbsp;&nbsp;&nbsp;&nbsp;</td>
-			<td><a href="http://youtu.be/cR4gw-cPZOA">Youtube tutorial</a></td>
-			<td>of the Authentication, Session Management and Users Management features of ZAP [external link to http://youtu.be/cR4gw-cPZOA].</td>
+			<td><a href="https://youtu.be/cR4gw-cPZOA">Youtube tutorial</a></td>
+			<td>of the Authentication, Session Management and Users Management features of ZAP [external link to https://youtu.be/cR4gw-cPZOA].</td>
 		</tr>
 		<tr>
 			<td>&nbsp;&nbsp;&nbsp;&nbsp;</td>

--- a/src/help/zaphelp/contents/ui/dialogs/options/jvm.html
+++ b/src/help/zaphelp/contents/ui/dialogs/options/jvm.html
@@ -49,8 +49,8 @@ Note that these options are not used when starting ZAP via the Windows exe.
 
 <H2>External links</H2>
 <table>
-<tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td><a href="http://docs.oracle.com/javase/7/docs/technotes/tools/windows/java.html#CBBIJCHG">Java 7 options</a></td></tr>
-<tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td><a href="http://docs.oracle.com/javase/8/docs/technotes/tools/windows/java.html#BABDJJFI">Java 8 options</a></td></tr>
+<tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td><a href="https://docs.oracle.com/javase/7/docs/technotes/tools/windows/java.html#CBBIJCHG">Java 7 options</a></td></tr>
+<tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td><a href="https://docs.oracle.com/javase/8/docs/technotes/tools/windows/java.html#BABDJJFI">Java 8 options</a></td></tr>
 </table>
 
 </BODY>

--- a/src/help/zaphelp/contents/ui/dialogs/options/view.html
+++ b/src/help/zaphelp/contents/ui/dialogs/options/view.html
@@ -92,7 +92,7 @@ This setting will only take effect when ZAP is restarted.
 <H2>External Links</H2>
 <table>
 <tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td>
-http://docs.oracle.com/javase/7/docs/api/java/text/SimpleDateFormat.html</td><td>For details of Java's SimpleDateFormat.</td></tr>
+https://docs.oracle.com/javase/7/docs/api/java/text/SimpleDateFormat.html</td><td>For details of Java's SimpleDateFormat.</td></tr>
 </table>
 
 </BODY>


### PR DESCRIPTION
Change HTTP links to HTTPS, when the latter is available.
Fix broken links (page content was no longer the expected).