### PR TITLE
Update name/description of Local Proxy option

### DIFF
--- a/src/help/zaphelp/contents/ui/dialogs/options/localproxy.html
+++ b/src/help/zaphelp/contents/ui/dialogs/options/localproxy.html
@@ -14,11 +14,11 @@ on which ZAP accepts incoming connections.<br/>
 It is this address and port that you must configure your browser to use as a proxy.
 </p>
 
-<H3>Modify/Remove "Accept-Encoding" request-header</H3>
-Allows the proxy to modify/remove the "Accept-Encoding" request-header field so 
-no encoding transformations are done to the response.<br/>
+<H3>Remove Unsupported Encodings</H3>
+Allows the proxy to remove unsupported encodings from the "Accept-Encoding" request-header field, so 
+no (unsupported) encoding transformations are done to the response.<br/>
 This option should be always enabled unless when testing the encoding transformations.<br/>
-The messages encoded will not be correctly scanned (either by passive and active scanners).
+The messages encoded with unsupported encodings will not be correctly scanned (either by passive and active scanners).
 
 <H2>See also</H2>
 <table>


### PR DESCRIPTION
Change "Options Local Proxy screen" page to update the name and
description of the option that (now) removes the unsupported encodings.

Part of zaproxy/zaproxy#2570 - Change proxy option to remove unsupported
encoding