### PR TITLE
Move advanced spider option to options page

### DIFF
--- a/src/help/zaphelp/contents/ui/dialogs/options/spider.html
+++ b/src/help/zaphelp/contents/ui/dialogs/options/spider.html
@@ -34,6 +34,12 @@
 	The maximum length of time that the spider should run for, measured in minutes.
 	Zero (the default) means that the spider will run until it has found all of the links that it is able to. 
 
+	<h3>Maximum children to crawl</h3>
+	This parameter limits the number of children that will be crawled at every node in the tree.<br>
+	This is useful for data driven applications that have large numbers of 'pages' that are in fact exactly the same code but 
+	containing different data, for example from a database.<br>
+	By default this is set to zero which means there are no limits applied to the number of child nodes crawled.
+
 	<h3>Domain Pattern</h3>
 	The normal behavior of the spider is to only follow links to resources
 	found on the same domain as the page where the scan started. However,

--- a/src/help/zaphelp/contents/ui/dialogs/spider.html
+++ b/src/help/zaphelp/contents/ui/dialogs/spider.html
@@ -28,13 +28,7 @@ Clicking on the 'Reset' button will reset all of the options to their default va
 
 <H2>Advanced</H2>
 
-Most of the parameters on this tab correspond to the same parameters on the <a href="options/spider.html">Options Spider screen</a>.<br>
-
-<h3>Maximum children to crawl</h3>
-This parameter limits the number of children that will be crawled at every node in the tree.<br>
-This is useful for data driven applications that have large numbers of 'pages' that are in fact exactly the same code but 
-containing different data, for example from a database.<br>
-By default this is set to zero which means there are no limits applied to the number of child nodes crawled.
+The parameters on this tab correspond to the same parameters on the <a href="options/spider.html">Options Spider screen</a>.
 
 <H2>Accessed via</H2>
 <table>


### PR DESCRIPTION
Move the advanced spider option "Maximum children to crawl" to spider
options page. The option will be available in the options panel as well.

Part of zaproxy/zaproxy#3066 - Spidering options in the doc in two place