### PR TITLE
Mention Replacer add-on in Filter notes

### DIFF
--- a/src/help/zaphelp/contents/start/concepts/filters.html
+++ b/src/help/zaphelp/contents/start/concepts/filters.html
@@ -9,7 +9,7 @@ Filters
 <BODY BGCOLOR="#ffffff">
 <H1>Filters</H1>
 <p>
-<strong>NOTE: Filters have in effect been replaced by scripts which are more powerful and flexible.<br>
+<strong>NOTE: Filters have in effect been replaced by Replacer add-on and scripts which are more powerful and flexible.<br>
 Filters will be removed in a future version of ZAP.</strong>
 </p>
 <p>

--- a/src/help/zaphelp/contents/ui/dialogs/filter.html
+++ b/src/help/zaphelp/contents/ui/dialogs/filter.html
@@ -9,7 +9,7 @@ Filter dialog
 <BODY BGCOLOR="#ffffff">
 <H1>Filter dialog</H1>
 <p>
-<strong>NOTE: Filters have in effect been replaced by scripts which are more powerful and flexible.<br>
+<strong>NOTE: Filters have in effect been replaced by Replacer add-on and scripts which are more powerful and flexible.<br>
 Filters will be removed in a future version of ZAP.</strong>
 </p>
 <p>


### PR DESCRIPTION
Change "Filter dialog" and "Filters" pages to mention that the Replacer
add-on is, along with scripts, the replacement for filters.