### PR TITLE
Tweak Behind NAT Local Proxy option

### DIFF
--- a/src/help/zaphelp/contents/ui/dialogs/options/localproxy.html
+++ b/src/help/zaphelp/contents/ui/dialogs/options/localproxy.html
@@ -20,6 +20,9 @@ determine the public IP address, to properly detect and handle requests with the
 IP address (for example, to be served by the ZAP API).
 <p>
 <strong>Note:</strong> This option is only supported when ZAP is running in an AWS EC2 instance.
+ZAP will obtain the public IP address from
+<a href="https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-instance-addressing.html#working-with-ip-addresses">AWS EC2
+instance's metadata</a>.<br>
 ZAP should be started with this option enabled if access to the API, through the public IP address, is required:
 <blockquote>zap.sh -daemon -port 8080 -host 0.0.0.0 -config proxy.behindnat=true</blockquote>
 Also, the <a href="api.html">API</a> needs to be configured to accept external IP addresses (i.e. the IP


### PR DESCRIPTION
Change "Options Local Proxy screen" page to mention from where the
public IP address, of the AWS EC2 instance, is obtained.