### PR TITLE
Document Default User Agent connection option

### DIFF
--- a/src/help/zaphelp/contents/ui/dialogs/options/connection.html
+++ b/src/help/zaphelp/contents/ui/dialogs/options/connection.html
@@ -14,6 +14,10 @@ The Options Connection screen allows you to configure the ZAP connection options
 <H3>Timeout in seconds</H3>
 This makes is easier to test slow applications.
 
+<H3>Default User Agent</H3>
+The user agent that ZAP should use when creating HTTP messages (for example, spider messages or CONNECT requests to outgoing
+proxy).
+
 <H3>Single Cookie Request Header</H3>
 Controls whether the ZAP's managed cookies (<a href="../../tlmenu/edit.html">Enable Session Tracking (Cookie)</a>) should be set
 on a single "Cookie" request header or multiple "Cookie" request headers, when sending an HTTP request to the server.


### PR DESCRIPTION
Change "Options Connection screen" page to document the option Default
User Agent.

Related to zaproxy/zaproxy#1768 - Update to use a more recent user-agent