### PR TITLE
Document Security Protocols options

### DIFF
--- a/src/help/zaphelp/contents/ui/dialogs/options/connection.html
+++ b/src/help/zaphelp/contents/ui/dialogs/options/connection.html
@@ -31,6 +31,10 @@ Defines for how long the successful DNS queries should be cached:<ul>
 <strong>Note:</strong> Changes are applied after a restart.<p>
 The option can also be set using the <code>-config</code> command line argument with the key <code>connection.dnsTtlSuccessfulQueries</code>.
 
+<H3>Security Protocols</H3>
+Allows to choose the SSL/TLS versions enabled for outgoing connections (for example, to servers). At least
+one version must be enabled, versions unsupported by the JRE will be unselected and disabled.
+
 <H3>Use Proxy chain</H3>
 This section allows you to connect to another proxy for outgoing connections.<br/>
 This is often required in a corporate environment.

--- a/src/help/zaphelp/contents/ui/dialogs/options/localproxy.html
+++ b/src/help/zaphelp/contents/ui/dialogs/options/localproxy.html
@@ -34,6 +34,10 @@ no (unsupported) encoding transformations are done to the response.<br/>
 This option should be always enabled unless when testing the encoding transformations.<br/>
 The messages encoded with unsupported encodings will not be correctly scanned (either by passive and active scanners).
 
+<H3>Security Protocols</H3>
+Allows to choose the SSL/TLS versions enabled for incoming connections (for example, from browsers). At least
+one version must be enabled, versions unsupported by the JRE will be unselected and disabled.
+
 <H2>See also</H2>
 <table>
 <tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td>


### PR DESCRIPTION
Change pages "Options Local Proxy screen" and "Options Connection
screen" to document the options Security Protocols.

Part of zaproxy/zaproxy#3359 - Missing Help details Options Connection
screen
Related to zaproxy/zaproxy#968 - Allow to choose the enabled SSL/TLS
protocols