### PR TITLE
Fix broken link and add an option panel to TOC

### DIFF
--- a/src/help/zaphelp/contents/ui/tabs/ascan.html
+++ b/src/help/zaphelp/contents/ui/tabs/ascan.html
@@ -12,7 +12,7 @@ Active Scan tab
 The Active Scan tab allows you to perform an <a href="../../start/concepts/ascan.html">active scan</a>.<br> 
 <br>
 The 'Scan Policy Manager' button <img src="../../images/fugue/equalizer.png" align="bottom" width="16" height="16" /> shows the
-<a href="dialogs/scanpolicymgr.html">Scan Policy Manager</a> dialog which allows configuration of <a href="../../start/concepts/scanpolicy.html">scan policies</a>.
+<a href="../dialogs/scanpolicymgr.html">Scan Policy Manager</a> dialog which allows configuration of <a href="../../start/concepts/scanpolicy.html">scan policies</a>.
 <br><br>
 The 'New Scan' button launches the <a href="../dialogs/advascan.html">Active Scan dialog</a> which allows you
 to specify exactly what should be scanned.

--- a/src/help/zaphelp/toc.xml
+++ b/src/help/zaphelp/toc.xml
@@ -96,6 +96,7 @@
          	<tocitem text="Anti CSRF Tokens" target="ui.dialogs.options.anticsrf"/>
          	<tocitem text="API" target="ui.dialogs.options.api"/>
             <tocitem text="Breakpoints" target="ui.dialogs.options.breakpoints"/>
+            <tocitem text="Callback Address" target="ui.dialogs.options.callback"/>
          	<tocitem text="Certificate" target="ui.dialogs.options.certificate"/>
          	<tocitem text="Check for Updates" target="ui.dialogs.options.checkforupdates"/>
 			<tocitem text="Connection" target="ui.dialogs.options.connection"/>


### PR DESCRIPTION
Fix broken link in Active Scan tab page.
Add the Callback Address option panel to the TOC.