### PR TITLE
Update docs to mention SSLv2Hello restrictions

### DIFF
--- a/src/help/zaphelp/contents/ui/dialogs/options/connection.html
+++ b/src/help/zaphelp/contents/ui/dialogs/options/connection.html
@@ -34,6 +34,7 @@ The option can also be set using the <code>-config</code> command line argument 
 <H3>Security Protocols</H3>
 Allows to choose the SSL/TLS versions enabled for outgoing connections (for example, to servers). At least
 one version must be enabled, versions unsupported by the JRE will be unselected and disabled.
+<br>The option SSLv2Hello must be selected in conjunction with at least one SSL/TLS version.
 
 <H3>Use Proxy chain</H3>
 This section allows you to connect to another proxy for outgoing connections.<br/>

--- a/src/help/zaphelp/contents/ui/dialogs/options/localproxy.html
+++ b/src/help/zaphelp/contents/ui/dialogs/options/localproxy.html
@@ -37,6 +37,7 @@ The messages encoded with unsupported encodings will not be correctly scanned (e
 <H3>Security Protocols</H3>
 Allows to choose the SSL/TLS versions enabled for incoming connections (for example, from browsers). At least
 one version must be enabled, versions unsupported by the JRE will be unselected and disabled.
+<br>The option SSLv2Hello must be selected in conjunction with at least one SSL/TLS version.
 
 <H2>See also</H2>
 <table>


### PR DESCRIPTION
Change pages "Options Local Proxy screen" and "Options Connection
screen" to mention that SSLv2Hello must be selected with other SSL/TLS
versions.

Part of zaproxy/zaproxy#3410 - Do not allow to choose just SSLv2Hello