### PR TITLE
Document Maximum parse size spider option

### DIFF
--- a/src/help/zaphelp/contents/ui/dialogs/options/spider.html
+++ b/src/help/zaphelp/contents/ui/dialogs/options/spider.html
@@ -40,6 +40,10 @@
 	containing different data, for example from a database.<br>
 	By default this is set to zero which means there are no limits applied to the number of child nodes crawled.
 
+	<h3>Maximum parse size</h3>
+	Defines the maximum size, in bytes, that a response might have to be parsed. This allows
+	the spider to skip big responses/files.
+
 	<h3>Domain Pattern</h3>
 	The normal behavior of the spider is to only follow links to resources
 	found on the same domain as the page where the scan started. However,


### PR DESCRIPTION
Change Options Spider screen page to document the spider option Maximum
parse size.

Part of zaproxy/zaproxy#1313 - Spider - Allow to configure the size
limit of parseable responses