### PR TITLE
Update Alerts concept page

### DIFF
--- a/src/help/zaphelp/contents/start/concepts/alerts.html
+++ b/src/help/zaphelp/contents/start/concepts/alerts.html
@@ -71,7 +71,7 @@ If it starts with a '-' then it is prepended to the existing information.
 <br>
 If it does not start with a '+' or '-' then it replaces the existing information.
 <p>
-The alert override configuration file can be specified via the 
+The alert override configuration file can be specified via the <a href="api.html">API</a>,
 <a href="../../ui/dialogs/options/alert.html">Options Alert screen</a>
 or using the <a href="../../cmdline.html">command line</a> option:  
 <pre>-config alert.overridesFilename=&lt;filename&gt;</pre>


### PR DESCRIPTION
Change Alerts concept page to mention that the alert overrides file can
also be set through the API.

Part of zaproxy/zaproxy#3443 - Expose Alerts options through the ZAP API