### PR TITLE
Add new API endpoints to release notes

### DIFF
--- a/src/help/zaphelp/contents/releases/2_7_0.html
+++ b/src/help/zaphelp/contents/releases/2_7_0.html
@@ -58,6 +58,30 @@ A new summary view for Alerts which displays counts of Alerts per Risk level. Op
 {"High":0,"Low":132,"Medium":39,"Informational":153}
 </code></pre></blockquote>
 
+<H3>VIEW core / optionAlertOverridesFilePath</H3>
+
+Gets the path to the file with alert overrides. 
+
+<H3>VIEW core / optionMaximumAlertInstances</H3>
+
+Gets the maximum number of alert instances to include in a report. 
+
+<H3>VIEW core / optionMergeRelatedAlerts</H3>
+
+Gets whether or not related alerts will be merged in any reports generated. 
+
+<H3>ACTION core / setOptionAlertOverridesFilePath</H3>
+
+Sets (or clears, if empty) the path to the file with alert overrides. 
+
+<H3>ACTION core / setOptionMaximumAlertInstances</H3>
+
+Sets the maximum number of alert instances to include in a report. A value of zero is treated as unlimited. 
+
+<H3>ACTION core / setOptionMergeRelatedAlerts</H3>
+
+Sets whether or not related alerts will be merged in any reports generated. 
+
 <H2>See also</H2>
 <table>
 <tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td><a href="../intro.html">Introduction</a></td><td>the introduction to ZAP</td></tr>


### PR DESCRIPTION
Change Release 2.7.0 page to add the new API endpoints that allow to
set/get the Alerts options.

Part of zaproxy/zaproxy#3443 - Expose Alerts options through the ZAP API