### PR TITLE
Update API concepts page

### DIFF
--- a/src/help/zaphelp/contents/start/concepts/api.html
+++ b/src/help/zaphelp/contents/start/concepts/api.html
@@ -18,19 +18,14 @@ when you are proxying via ZAP, or via the host and port ZAP is listening on, eg
 <a href="http://localhost:8080/">http://localhost:8080/</a>.<br/>
 </p>
 <p>
-If enabled then the API is available to all machines that are able to use ZAP as a proxy.<br/>
-By default ZAP listens only on 'localhost' and so can only be used from the host machine.
+By default only the machine ZAP is running on is able to access the API. You can allow other machines, that are able to use ZAP
+as a proxy, access to the API. The API is configured using the <a href="../../ui/dialogs/options/api.html">Options API screen</a>.
 </p>
 
 <p>
 The API provides access to most of the core ZAP features such as the 
  <a href="ascan.html">active scanner</a> and <a href="spider.html">spider</a>.<br/>
 Future versions of ZAP will increase the functionality available via the APi.
-</p>
-
-<p>
-The API is configured using the 
-<a href="../../ui/dialogs/options/api.html">Options API screen</a>.
 </p>
 
 


### PR DESCRIPTION
Change API concept page to mention that the API is only accessible, by
default, to the local machine, not all machines that can proxy through
ZAP.