### PR TITLE
Add changed API endpoint to release notes

### DIFF
--- a/src/help/zaphelp/contents/releases/2_7_0.html
+++ b/src/help/zaphelp/contents/releases/2_7_0.html
@@ -49,6 +49,9 @@ and 3 for High.
 Added optional riskId parameter to facilitate filtering the risk. Where riskId is in the range 0 for Informational 
 and 3 for High. 
 
+<H3>VIEW core / urls</H3>
+Added optional <code>baseurl</code> parameter, to filter the URLs that are returned.
+
 <H2>ZAP API New Endpoints:</H2>
 
 <H3>VIEW core / alertsSummary</H3>


### PR DESCRIPTION
Change Release 2.7.0 page to add the changed API endpoint core view
"urls", now allows to filter by base URL.

Part of zaproxy/zaproxy#3457 - Allow to filter core view "urls" by base
URL