### PR TITLE
Document Browse API menu item

### DIFF
--- a/src/help/zaphelp/contents/ui/tlmenu/tools.html
+++ b/src/help/zaphelp/contents/ui/tlmenu/tools.html
@@ -13,6 +13,9 @@ This menu handles the tools and general options.
 <H3>Filter....</H3>
 This displays the <a href="../dialogs/filter.html">Filter dialog</a>.
 
+<H3>Browse API</H3>
+Opens the <a href="../../start/concepts/api.html">ZAP API</a> in the system's default browser.
+
 <H3>Encode/Decode/Hash...</H3>
 This displays the <a href="../dialogs/enc_dec.html">Encode/Decode/Hash dialog</a>.
 


### PR DESCRIPTION
Change The Tools menu page to document the Browse API menu item.

Related to zaproxy/zaproxy#3467 - Use local proxy address for Browse API
menu