### PR TITLE
Add info related to new Help Support Info menuitem

### DIFF
--- a/src/help/zaphelp/contents/cmdline.html
+++ b/src/help/zaphelp/contents/cmdline.html
@@ -48,6 +48,7 @@ ZAP supports the following command line options:
 <tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td>-addonlist</td><td>List all of the installed add-ons</td></tr>
 <tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td>-script &lt;script&gt;</td><td>Run the specified script (file system path) if command line/daemon, or just load it if GUI</td></tr>
 <tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td>-last_scan_report &lt;path&gt;</td><td>Generate the 'Last Scan Report' into the specified path</td></tr>
+<tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td>-suppinfo</td><td>Outputs details relevant for support and troubleshooting (to the console/standard out). Such as: ZAP version, java version, installed add-ons and version, locale info, operating system, etc.</td></tr>
 </table>
 <br>
 The options <code>-session</code> and <code>-newsession</code> are mutually exclusive. An error will be shown and ZAP exit (if not in GUI) when both options are set.

--- a/src/help/zaphelp/contents/ui/tlmenu/help.html
+++ b/src/help/zaphelp/contents/ui/tlmenu/help.html
@@ -13,6 +13,13 @@ This menu gives access to the 'about' dialog and this help file.
 <H3>About ZAP</H3>
 This displayed the 'about' dialog.
 
+<H3>Support Info...</H3>
+Displays a dialog that contains information which is useful when troubleshooting or seeking support. Such as:<br>
+Version, installed add-ons and versions, operating system, java version, locale info, and ZAP Home Directory path.
+This information can be copied and pasted. <br>
+The dialog includes an "Open" button, which assuming the OS supports the necessary functionality, will open the ZAP Home Directory 
+(for logs or configuration files) when clicked.
+
 <H3>ZAP - User Guide</H3>
 Displays this help file.
 


### PR DESCRIPTION
Updated /ui/tlmenu/help.html to include information about the recently added "Support Info..." help menuitem.
Updated /zaphelp/contents/cmdline.html to include information about the recently added "-suppinfo" CLI switch.

Fixes zaproxy/zaproxy#3460