### PR TITLE
Correct labels of top level menus

### DIFF
--- a/src/help/zaphelp/contents/ui/tlmenu/analysis.html
+++ b/src/help/zaphelp/contents/ui/tlmenu/analysis.html
@@ -3,11 +3,11 @@
 <HEAD>
 <META HTTP-EQUIV="Content-Type" CONTENT="text/html; charset=utf-8">
 <TITLE>
-The Analysis menu
+The Analyse menu
 </TITLE>
 </HEAD>
 <BODY BGCOLOR="#ffffff">
-<H1>The Analysis menu</H1>
+<H1>The Analyse menu</H1>
 This menu handles the scan policy.
 <p>
 The spider and scan options that were in this menu in an earlier version are now available via the

--- a/src/help/zaphelp/contents/ui/tlmenu/edit.html
+++ b/src/help/zaphelp/contents/ui/tlmenu/edit.html
@@ -47,9 +47,6 @@ The relevant message will be selected in the Search tab and the string will be d
 and highlighted in the <a href="../tabs/request.html">Request</a> or
 <a href="../tabs/response.html">Response</a> tab as appropriate.
 
-<H3>Encode/Decode/Hash...</H3>
-This displays the <a href="../dialogs/enc_dec.html">Encode/Decode/Hash dialog</a>.
-
 <p>
 Note that <a href="../../start/concepts/addons.html">add-ons</a> can add additional menu items.
 </p>

--- a/src/help/zaphelp/contents/ui/tlmenu/file.html
+++ b/src/help/zaphelp/contents/ui/tlmenu/file.html
@@ -28,9 +28,15 @@ You only need to persist it once - after that all changes will be saved.
 This saves a snapshot of a session that has already been persisted.<br/>
 It will suggest the same filename as the persisted session with a date-time string appended to it, and allow the user to set whatever name they choose.<br/>
 
-<H3>Properties...</H3>
+<H3>Session Properties...</H3>
 This displays the <a href="../dialogs/session/sessprop.html">Session Properties</a> dialog.<br/>
 This allows you to set the session name and description.
+
+<H3>Import Context...</H3>
+Allows to import a <a href="../../start/concepts/contexts.html">Context</a>.
+
+<H3>Export Context...</H3>
+Allows to export a Context.
 
 <H3>Load Add-on file...</H3>
 Load a local <a href="../../start/concepts/addons.html">add-on</a> file.<br/>
@@ -38,7 +44,7 @@ Add-ons are typically installed from via the <a href="../dialogs/manageaddons.ht
 option can be useful if you have downloaded an add-on manually or are testing one you have developed yourself.<br/>
 Add-ons remain installed until you manually uninstall them. 
 
-<H3>Exit and delete session...</H3>
+<H3>Exit and Delete Session...</H3>
 This will exit ZAP and delete the session, even if you have previously persisted it.<br/>
 The session will no longer be accessible when you restart ZAP, although any snapshots you took will still be available.<br/> 
 A warning dialog will be displayed to ensure you really meant to choose this option.

--- a/src/help/zaphelp/contents/ui/tlmenu/help.html
+++ b/src/help/zaphelp/contents/ui/tlmenu/help.html
@@ -10,7 +10,7 @@ The Help menu
 <H1>The Help menu</H1>
 This menu gives access to the 'about' dialog and this help file.
 
-<H3>About ZAP</H3>
+<H3>About OWASP ZAP</H3>
 This displayed the 'about' dialog.
 
 <H3>Support Info...</H3>
@@ -20,11 +20,11 @@ This information can be copied and pasted. <br>
 The dialog includes an "Open" button, which assuming the OS supports the necessary functionality, will open the ZAP Home Directory 
 (for logs or configuration files) when clicked.
 
-<H3>ZAP - User Guide</H3>
-Displays this help file.
-
 <H3>Check For Updates...</H3>
 This checks to see if you are running the latest version of ZAP.
+
+<H3>OWASP ZAP User Guide</H3>
+Displays this help file.
 
 <p>
 Note that <a href="../../start/concepts/addons.html">add-ons</a> can add additional menu items.

--- a/src/help/zaphelp/contents/ui/tlmenu/report.html
+++ b/src/help/zaphelp/contents/ui/tlmenu/report.html
@@ -10,11 +10,14 @@ The Report menu
 <H1>The Report menu</H1>
 This menu handles the reports.
 
-<H3>Generate HTML Report ...</H3>
+<H3>Generate HTML Report...</H3>
 This generates a new HTML report containing the alerts raised.
 
-<H3>Generate XML Report ...</H3>
+<H3>Generate XML Report...</H3>
 This generates a new XML report containing the alerts raised.
+
+<H3>Generate Markdown Report...</H3>
+This generates a new Markdown report containing the alerts raised.
 
 <H3>Export Messages to File...</H3>
 This allows you to save requests and responses to a text file. <br/>

--- a/src/help/zaphelp/contents/ui/tlmenu/tlmenu.html
+++ b/src/help/zaphelp/contents/ui/tlmenu/tlmenu.html
@@ -18,7 +18,7 @@ By default the following top level menu items will be present:<br/>
 <tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td>
 <a href="view.html">View menu</a> </td><td> This handles the display options</td></tr>
 <tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td>
-<a href="analysis.html">Analysis menu</a> </td><td> This handles spidering and automated scanning</td></tr>
+<a href="analysis.html">Analyse menu</a> </td><td> This handles Scan Policies</td></tr>
 <tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td>
 <a href="report.html">Report menu</a> </td><td> This handles the reports</td></tr>
 <tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td>

--- a/src/help/zaphelp/contents/ui/tlmenu/view.html
+++ b/src/help/zaphelp/contents/ui/tlmenu/view.html
@@ -14,9 +14,20 @@ This menu handles the display options.
 If selected then images will be displayed in the <a href="../tabs/history.html">History tab</a>.
 <br/>
 
-<H3>Show tab</H3>
+<H3>Show Tab</H3>
 This allows you to show any of the tabs available, including those you have hidden.
-<br/>
+
+<H3>Show All Tabs</H3>
+This allows you to show all tabs.
+
+<H3>Hide Unpinned Tabs</H3>
+This allows you to hide all tabs that are not pinned.
+
+<H3>Pin All Visible Tabs</H3>
+This allows you to pin all visible tabs.
+
+<H3>Unpin All Tabs</H3>
+This allows you unpin all tabs.
 
 <p>
 Note that <a href="../../start/concepts/addons.html">add-ons</a> can add additional menu items.


### PR DESCRIPTION
Correct the labels of top level menus and menu items (e.f. different
case, missing or different words).
Document some missing menu items, reorder and remove one that was no
longer in the menu.