### PR TITLE
Update Extension/Add-on pages

### DIFF
--- a/src/help/zaphelp/contents/start/concepts/addons.html
+++ b/src/help/zaphelp/contents/start/concepts/addons.html
@@ -34,6 +34,13 @@ Alpha</td><td>which indicates they are at an early stage of development</td></tr
 </table>
 </p>
 
+<H3>Location of add-ons available to ZAP</H3>
+To make an add-on available to ZAP it must be in one of the following locations:
+<ul>
+	<li><code>plugin</code> directory located in the ZAP's installation folder;</li>
+	<li><code>plugin</code> directory located in the ZAP's user folder.</li>
+</ul>
+
 <H2>See also</H2>
 <table>
 <tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td>

--- a/src/help/zaphelp/contents/ui/dialogs/options/checkforupdates.html
+++ b/src/help/zaphelp/contents/ui/dialogs/options/checkforupdates.html
@@ -46,8 +46,8 @@ These add-ons will have been reviewed but they are typically at an early stage o
 They may be incomplete, contain significant issues or cause stability problems.
 
 <H3>Add-on directories</H3>
-ZAP will load all of the add-ons located in the release 'plugins' directory as well as any that have been downloaded
-and are in the local 'plugins' directory.<br>
+ZAP will load all of the add-ons from the <a href="../../../start/concepts/addons.html">default <code>plugin</code>
+directories</a>.<br>
 You can also add as many additional add-on directories as you need by adding them here.<br>
 This can be very useful when running multiple ZAP instances on one machine, for example in a CI environment.<br>
 You can then just download new or updated add-ons once and immediately share them between multiple instances.<br>

--- a/src/help/zaphelp/contents/ui/dialogs/options/ext.html
+++ b/src/help/zaphelp/contents/ui/dialogs/options/ext.html
@@ -7,7 +7,7 @@
 <BODY BGCOLOR="#ffffff">
 	<H1>Options Extensions screen</H1>
 	<p>This screen allows you to enable/disable extensions that are
-		available to ZAP.</p>
+		available to ZAP, either core or added by <a href="../../../start/concepts/addons.html">add-ons</a>.</p>
 	<H3>Enable/Disable Extensions</H3>
 	Enabled extensions will be loaded by ZAP, thus adding the
 	functionalities provided by those extensions. Disabled extensions will
@@ -28,14 +28,6 @@
 	when disabling one extension other extensions (that depend on it) will
 	also be disabled. Automatically disabled extensions will not be allowed
 	to be enabled until all the dependencies are enabled.
-
-	<H3>Location of extensions available to ZAP</H3>
-	To make an extension available to ZAP it must be in one the following
-	locations:
-	<ul>
-		<li>"plugin" directory located in the ZAP's folder;</li>
-		<li>"plugin" directory located in the ZAP user's folder.</li>
-	</ul>
 
 	<p>
 		<i>Note: You will need to restart ZAP for the changes to take


### PR DESCRIPTION
Change Options Extensions screen page to remove outdated information
(the packaged extensions are no longer loaded by ZAP, superseded by
add-ons) and mention that the add-ons can provide extensions.
Update Add-ons concepts page with the directories used to load the
add-ons (moved and adapted from Options Extensions screen page).
Update Options Check for Updates screen page to point to the concepts
page when referring to the default directories.