### PR TITLE
Correct tab name when importing root CA cert

### DIFF
--- a/src/help/zaphelp/contents/ui/dialogs/options/dynsslcert.html
+++ b/src/help/zaphelp/contents/ui/dialogs/options/dynsslcert.html
@@ -230,8 +230,8 @@ And yes, that example will work - its the Superfish certificate!
 	<li>Go to Preferences</li>
 	<li>Tab Advanced</li>
 	<li>Tab Cryptography/Certificates</li>
-	<li>Click View certificates</li>
-	<li>Click tab Trusted root certificates</li>
+	<li>Click View Certificates</li>
+	<li>Click Authorities tab</li>
 	<li>Click Import and choose the saved <tt>owasp_zap_root_ca.cer</tt> file</li>
 	<li>In the wizard choose to trust this certificate to identify web sites (check on the boxes)</li>
 	<li>Finalize the wizard</li>


### PR DESCRIPTION
Change Dynamic SSL Certificates options page to correct the name of the
tab when importing ZAP's Root CA cert into Firefox ("Authorities tab"
instead of "Trusted root certificates tab"), also, correct case of
button label.

Related to zaproxy/zaproxy#3724 - Wrong step in Getting Started Guide