### PR TITLE
Add new API endpoint to release notes

### DIFF
--- a/src/help/zaphelp/contents/releases/2_7_0.html
+++ b/src/help/zaphelp/contents/releases/2_7_0.html
@@ -85,6 +85,10 @@ Sets the maximum number of alert instances to include in a report. A value of ze
 
 Sets whether or not related alerts will be merged in any reports generated. 
 
+<H3>ACTION ascan / importScanPolicy</H3>
+
+Imports a Scan Policy using the given file system path.
+
 <H2>See also</H2>
 <table>
 <tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td><a href="../intro.html">Introduction</a></td><td>the introduction to ZAP</td></tr>


### PR DESCRIPTION
Change Release 2.7.0 page to add the new API endpoint that allows to
import a scan policy.

Part of zaproxy/zaproxy#1604 - Import policy file via API