### PR TITLE
Update Configuring Proxies for Firefox on Linux

### DIFF
--- a/src/help/zaphelp/contents/start/proxies.html
+++ b/src/help/zaphelp/contents/start/proxies.html
@@ -26,7 +26,7 @@ Instructions for the latest versions of the most commonly used browsers:
 <tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td>Follow the</td><td> 'Windows LAN Settings' section below</td></tr>
 </table>
 
-<H3>Firefox</H3>
+<H3>Firefox (on Windows)</H3>
 <table>
 <tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td>Select the</td><td> 'Tools' menu </td></tr>
 <tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td>Select the</td><td> 'Options..' menu item</td></tr>
@@ -40,6 +40,13 @@ Instructions for the latest versions of the most commonly used browsers:
 <a href="../ui/dialogs/options/localproxy.html">Options Local Proxy screen</a></td></tr>
 <tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td>Press the</td><td> Connection Setting 'OK' button</td></tr>
 <tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td>Press the</td><td> Options 'OK' button</td></tr>
+</table>
+
+<H3>Firefox (on Linux)</H3>
+<table>
+<tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td>Select the</td><td>'Edit' menu</td></tr>
+<tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td>Select the</td><td>'Preferences' menu item</td></tr>
+<tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td>Follow the</td><td>instructions above from the 'Advanced' button</td></tr>
 </table>
 
 <H3>Firefox (on OS X)</H3>


### PR DESCRIPTION
Change Configuring Proxies page to include the steps on how to configure
Firefox's outgoing proxy on Linux (different menu and menu item than
Windows).