### PR TITLE
Add API endpoint zapHomePath to release notes

### DIFF
--- a/src/help/zaphelp/contents/releases/2_7_0.html
+++ b/src/help/zaphelp/contents/releases/2_7_0.html
@@ -73,6 +73,10 @@ Gets the maximum number of alert instances to include in a report.
 
 Gets whether or not related alerts will be merged in any reports generated. 
 
+<H3>VIEW core / zapHomePath</H3>
+
+Gets the path to ZAP's home directory.
+
 <H3>ACTION core / setOptionAlertOverridesFilePath</H3>
 
 Sets (or clears, if empty) the path to the file with alert overrides. 


### PR DESCRIPTION
Change Release 2.7.0 page to add the new API endpoint that allows to
get the home directory currently used by ZAP.

Part of zaproxy/zaproxy#3367 - Expose ZAP's home dir path through the
ZAP API