### PR TITLE
Add changed API endpoint to release notes

### DIFF
--- a/src/help/zaphelp/contents/releases/2_7_0.html
+++ b/src/help/zaphelp/contents/releases/2_7_0.html
@@ -52,6 +52,9 @@ and 3 for High.
 <H3>VIEW core / urls</H3>
 Added optional <code>baseurl</code> parameter, to filter the URLs that are returned.
 
+<H3>VIEW ascan / scanProgress</H3>
+Changed to also return the number of alerts raised by each scanner.
+
 <H2>ZAP API New Endpoints:</H2>
 
 <H3>VIEW core / alertsSummary</H3>


### PR DESCRIPTION
Change Release 2.7.0 page to add the changed API endpoint ascan view
"scanProgress", now returns the number of alerts raised by each scanner.

Part of zaproxy/zaproxy#3733 - Ascan API - Return alert count for each
scanner