### PR TITLE
Add API views messages[Har]ById to release notes

### DIFF
--- a/src/help/zaphelp/contents/releases/2_7_0.html
+++ b/src/help/zaphelp/contents/releases/2_7_0.html
@@ -64,6 +64,12 @@ A new summary view for Alerts which displays counts of Alerts per Risk level. Op
 {"High":0,"Low":132,"Medium":39,"Informational":153}
 </code></pre></blockquote>
 
+<H3>VIEW core / messagesById</H3>
+Gets the HTTP messages with the given IDs.
+
+<H3>VIEW core / messagesHarById</H3>
+Gets the HTTP messages with the given IDs, in HAR format.
+
 <H3>VIEW core / optionAlertOverridesFilePath</H3>
 
 Gets the path to the file with alert overrides. 


### PR DESCRIPTION
Change Release 2.7.0 page to add the new API core views messagesById and
messagesHarById.

Part of zaproxy/zaproxy#3514 - Allow to obtain multiple messages by ID