### PR TITLE
Add API breaking change to release notes

### DIFF
--- a/src/help/zaphelp/contents/releases/2_7_0.html
+++ b/src/help/zaphelp/contents/releases/2_7_0.html
@@ -39,6 +39,10 @@ and:
 &lt;contextList&gt;[Context 1, Context 2]&lt;/contextList&gt;
 </code></pre></blockquote>
 
+<H3>VIEW core / setOptionUseProxyChain</H3>
+Changed to return <code>FAIL</code> if the outgoing proxy was not enabled (because the required address/hostname was not
+previously set), before it would return always <code>OK</code>.
+
 <H2>ZAP API Changed Endpoints:</H2>
 
 <H3>VIEW core / alerts</H3>


### PR DESCRIPTION
Change Release 2.7.0 page to mention the (potential) breaking change
done to API core view setOptionUseProxyChain.

Part of zaproxy/zaproxy#3696 - Correct API response for outgoing proxy
changes