### PR TITLE
Add API action deleteAlert to release notes

### DIFF
--- a/src/help/zaphelp/contents/releases/2_7_0.html
+++ b/src/help/zaphelp/contents/releases/2_7_0.html
@@ -80,6 +80,9 @@ Gets whether or not related alerts will be merged in any reports generated.
 
 Gets the path to ZAP's home directory.
 
+<H3>ACTION core / deleteAlert</H3>
+Deletes the alert with the given ID.
+
 <H3>ACTION core / setOptionAlertOverridesFilePath</H3>
 
 Sets (or clears, if empty) the path to the file with alert overrides. 


### PR DESCRIPTION
Change Release 2.7.0 page to add the new API core action deleteAlert.

Part of zaproxy/zaproxy#3676 - Delete single Alert using the api