### PR TITLE
Add changed API view ascan/scans to release notes

### DIFF
--- a/src/help/zaphelp/contents/releases/2_7_0.html
+++ b/src/help/zaphelp/contents/releases/2_7_0.html
@@ -52,6 +52,9 @@ and 3 for High.
 <H3>VIEW core / urls</H3>
 Added optional <code>baseurl</code> parameter, to filter the URLs that are returned.
 
+<H3>VIEW ascan / scans</H3>
+Changed to also return the total number of alerts raised and messages sent during each scan.
+
 <H3>VIEW ascan / scanProgress</H3>
 Changed to also return the number of alerts raised by each scanner.
 


### PR DESCRIPTION
Change Release 2.7.0 page to add the changed API endpoint ascan view
scans, now returns the total number of alerts raised and messages sent
during each scan.

Part of zaproxy/zaproxy#3782 - Add msg and alert count to active scans
API view