### PR TITLE
Update doc links to refer to Java 8

### DIFF
--- a/src/help/zaphelp/contents/ui/dialogs/options/jvm.html
+++ b/src/help/zaphelp/contents/ui/dialogs/options/jvm.html
@@ -49,7 +49,6 @@ Note that these options are not used when starting ZAP via the Windows exe.
 
 <H2>External links</H2>
 <table>
-<tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td><a href="https://docs.oracle.com/javase/7/docs/technotes/tools/windows/java.html#CBBIJCHG">Java 7 options</a></td></tr>
 <tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td><a href="https://docs.oracle.com/javase/8/docs/technotes/tools/windows/java.html#BABDJJFI">Java 8 options</a></td></tr>
 </table>
 

--- a/src/help/zaphelp/contents/ui/dialogs/options/view.html
+++ b/src/help/zaphelp/contents/ui/dialogs/options/view.html
@@ -92,7 +92,7 @@ This setting will only take effect when ZAP is restarted.
 <H2>External Links</H2>
 <table>
 <tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td>
-https://docs.oracle.com/javase/7/docs/api/java/text/SimpleDateFormat.html</td><td>For details of Java's SimpleDateFormat.</td></tr>
+<a href="https://docs.oracle.com/javase/8/docs/api/java/text/SimpleDateFormat.html">Details of Java's SimpleDateFormat</a></td></tr>
 </table>
 
 </BODY>


### PR DESCRIPTION
Change Options Display screen page to use Java 8 JavaDocs (and make it a
link).
Change Options JVM screen page to refer just to Java 8 docs (Java 7 no
longer works).

Part of zaproxy/zaproxy#3470 - Move to using Java 8