### PR TITLE
Add API action skipScanner to release notes

### DIFF
--- a/src/help/zaphelp/contents/releases/2_7_0.html
+++ b/src/help/zaphelp/contents/releases/2_7_0.html
@@ -112,6 +112,9 @@ Sets whether or not related alerts will be merged in any reports generated.
 
 Imports a Scan Policy using the given file system path.
 
+<H3>ACTION ascan / skipScanner</H3>
+Skips the scanner using the IDs of the scan and the scanner.
+
 <H2>See also</H2>
 <table>
 <tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td><a href="../intro.html">Introduction</a></td><td>the introduction to ZAP</td></tr>


### PR DESCRIPTION
Change Release 2.7.0 page to add the new API ascan action skipScanner.

Part of zaproxy/zaproxy#3910 - Allow to skip scanners through the API