### PR TITLE
Add new API spider action/view to release notes

### DIFF
--- a/src/help/zaphelp/contents/releases/2_7_0.html
+++ b/src/help/zaphelp/contents/releases/2_7_0.html
@@ -93,6 +93,9 @@ Gets whether or not related alerts will be merged in any reports generated.
 
 Gets the path to ZAP's home directory.
 
+<H3>VIEW spider / optionAcceptCookies</H3>
+Gets whether or not a spider process should accept cookies while spidering.
+
 <H3>ACTION core / deleteAlert</H3>
 Deletes the alert with the given ID.
 
@@ -114,6 +117,9 @@ Imports a Scan Policy using the given file system path.
 
 <H3>ACTION ascan / skipScanner</H3>
 Skips the scanner using the IDs of the scan and the scanner.
+
+<H3>ACTION spider / setOptionAcceptCookies</H3>
+Sets whether or not a spider process should accept cookies while spidering.
 
 <H2>See also</H2>
 <table>


### PR DESCRIPTION
Change Release 2.7.0 page to add the new API spider view and action for
the option accepts cookies.

Related to zaproxy/zaproxy#3395 - Add option to spider anonymously with
a session