### PR TITLE
Document the formatting locale option

### DIFF
--- a/src/help/zaphelp/contents/ui/dialogs/options/language.html
+++ b/src/help/zaphelp/contents/ui/dialogs/options/language.html
@@ -16,6 +16,9 @@ The language ZAP uses for its display.<br>
 A set of languages are built into ZAP, however more languages may be available after the last release.<br>
 Check the ZAP download page for the latest language pack available.<br>
 
+<H3>Use system's locale for formatting</H3>
+If the formatting of numbers, dates, and times is done with the system's locale instead of the locale of the selected language.
+
 <H3>Language pack import</H3>
 Besides the selection of the language that is used for ZAP's display, the import tool enables you to import new language packs or language file updates.
 A language file pack will always have the extension <em>zaplang</em>. (E.g. language-pack-en_GB.zaplang)


### PR DESCRIPTION
Change Options language screen page to document the option Use system's
locale for formatting.

Part of zaproxy/zaproxy#3587 - Allow to use system's locale for
formatting