### PR TITLE
Mention local proxies in Exclude from Proxy

### DIFF
--- a/src/help/zaphelp/contents/ui/dialogs/session/sessprop.html
+++ b/src/help/zaphelp/contents/ui/dialogs/session/sessprop.html
@@ -15,7 +15,7 @@ This allows you to set the session properties and is made up of the following sc
 This allows you to set the session name and description.
 
 <H3>Exclude from Proxy</H3>
-This allows you to manage the URLs which will be ignored by the proxy.
+This allows you to manage the URLs which will be ignored by the local proxies.
 
 <H3>Exclude from Scanner</H3>
 This allows you to manage the URLs which will be ignored by the scanner.


### PR DESCRIPTION
Change Session Properties dialogue page to mention that the Exclude from
Proxy option now applies to the local proxies (not just main local
proxy).

Part of zaproxy/zaproxy#4062 - Honour proxy exclusions in additional
proxies