### PR TITLE
Document authentication API breaking change

### DIFF
--- a/src/help/zaphelp/contents/releases/2_8_0.html
+++ b/src/help/zaphelp/contents/releases/2_8_0.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 3.2 Final//EN">
+<HTML>
+<HEAD>
+<META HTTP-EQUIV="Content-Type" CONTENT="text/html; charset=utf-8">
+<TITLE>
+  Release 2.8.0
+</TITLE>
+</HEAD>
+<BODY BGCOLOR="#ffffff">
+<H1>Release 2.8.0</H1>
+
+<H2>Enhancements</H2>
+
+<H2>Bug fixes</H2>
+
+<H2>ZAP API Breaking Changes:</H2>
+
+<H3>VIEW authentication / getAuthenticationMethod</H3>
+
+This change will break the consumers that were manually parsing/extracting the JSON response (and XML response, for manual
+authentication method). The structure of the data was changed to have an object wrap the authentication method data, to be
+consistent with all other views. The returned data would be, for example:
+<blockquote><pre><code>
+{
+  "method": {
+    "port": "443",
+    "host": "example.com",
+    "methodName": "httpAuthentication",
+    "realm": "example"
+  }
+}
+</code></pre></blockquote>
+
+instead of:
+<blockquote><pre><code>
+{
+  "port": "443",
+  "host": "example.com",
+  "methodName": "httpAuthentication",
+  "realm": "example"
+}
+</code></pre></blockquote>
+
+<H2>ZAP API Changed Endpoints:</H2>
+
+<H2>ZAP API New Endpoints:</H2>
+
+<H2>See also</H2>
+<table>
+<tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td><a href="../intro.html">Introduction</a></td><td>the introduction to ZAP</td></tr>
+<tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td><a href="releases.html">Releases</a></td><td>the full set of releases</td></tr>
+<tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td><a href="../credits.html">Credits</a></td><td>the people and groups who have made this release possible</td></tr>
+</table>
+</BODY>
+</HTML>


### PR DESCRIPTION
Add an entry to the release notes about API breaking changes and
document the change of the data returned by the authentication view.

Part of zaproxy/zaproxy#4097 - python api returns the wrong content for
authentication.get_authentication_method()