### PR TITLE
Document alerts summary API breaking change

### DIFF
--- a/src/help/zaphelp/contents/releases/2_8_0.html
+++ b/src/help/zaphelp/contents/releases/2_8_0.html
@@ -41,6 +41,32 @@ instead of:
 }
 </code></pre></blockquote>
 
+<H3>VIEW core / alertsSummary</H3>
+
+This change will break the consumers that were manually parsing/extracting the JSON response. The structure of the data was
+changed to have an object wrap the alerts summary, to be consistent with all other views. The returned data would be, for
+example:
+<blockquote><pre><code>
+{
+  "alertsSummary": {
+    "High": 0,
+    "Low": 3,
+    "Medium": 1,
+    "Informational": 1
+  }
+}
+</code></pre></blockquote>
+
+instead of:
+<blockquote><pre><code>
+{
+  "High": 0,
+  "Low": 3,
+  "Medium": 1,
+  "Informational": 1
+}
+</code></pre></blockquote>
+
 <H2>ZAP API Changed Endpoints:</H2>
 
 <H2>ZAP API New Endpoints:</H2>


### PR DESCRIPTION
Document the change of the structure returned by the "alertsSummary"
core view.

Part of zaproxy/zaproxy#4111 - ZAP Python API:
zap.context.alerts_summary() returns 0