### PR TITLE
Document SNI capability in Local Proxies

### DIFF
--- a/src/help/zaphelp/contents/ui/dialogs/options/localproxy.html
+++ b/src/help/zaphelp/contents/ui/dialogs/options/localproxy.html
@@ -54,6 +54,17 @@ You can add as many additional addresses and ports for ZAP to listen on as you l
 This can be useful when testing mobile applications - you can proxy the mobile application via a Wi-Fi interface at the same time
 as using the backend site directly using a browser proxying through ZAP emulating a mobile user agent.
 
+<H2>Intercepting/Transparent Proxy</H2>
+The local proxies can be used as intercepting/transparent proxies for both HTTP and HTTPS. For HTTPS the client applications
+(e.g. browser) need to use the TLS extension <a href="https://tools.ietf.org/html/rfc6066#section-3">Server Name Indication</a>.
+This allows you to set up a testing LANs (or VMs) where all HTTP and HTTPS traffic is proxied regardless of software settings.
+<p>
+For example, if you have a Linux machine you use for testing, you can do something like the following to forward all HTTP and
+HTTPS traffic to a local proxy listening on <code>192.168.0.14:8080</code>:
+<pre><code>iptables -t nat -A OUTPUT -p tcp --dport 443 -j DNAT --to-destination 192.168.0.14:8080
+iptables -t nat -A OUTPUT -p tcp --dport 80 -j DNAT --to-destination 192.168.0.14:8080
+</code></pre>
+
 <H2>See also</H2>
 <table>
 <tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td>


### PR DESCRIPTION
Change Options Local Proxies screen page to document that the local
proxies can be used as intercepting proxies, for HTTPS using SNI.

Part of zaproxy/zaproxy#1015 - Support Server Name Indication

---
Based on https://github.com/zaproxy/zap-extensions/wiki/HelpAddonsSniTerminatorSniTerminator