### PR TITLE
Mention env var used in Windows for JVM options

### DIFF
--- a/src/help/zaphelp/contents/ui/dialogs/options/jvm.html
+++ b/src/help/zaphelp/contents/ui/dialogs/options/jvm.html
@@ -26,8 +26,8 @@ Good values for this field could be:
 <li>-Xmx1024m</li>
 </ul>
 <p>
-Unlike the other ZAP options these are held in the file ".ZAP_JVM.properties" in the user's default ZAP directory,
-which depends on the OS being used:
+Unlike the other ZAP options these are held in the file <code>.ZAP_JVM.properties</code> in the user's default ZAP directory,
+which depends on the OS being used, for example:
 <ul>
 <li>Windows 7/8: C:\Users\<i>&lt;username&gt;</i>\OWASP ZAP</li>
 <li>Windows XP: C:\Documents and Settings\<i>&lt;username&gt;</i>\OWASP ZAP</li>
@@ -36,10 +36,8 @@ which depends on the OS being used:
 </ul>
 If you make a mistake when setting these options then ZAP may fail to start.<br>
 If that happens then deleting this file should fix the problem.
-</p>
 <p>
-Note that these options are not used when starting ZAP via the Windows exe.
-</p>
+<strong>Windows Notes:</strong> These options are not used when starting ZAP via the executable. The directory where the file <code>.ZAP_JVM.properties</code> is located depends on the environment variable <code>%USERPROFILE%</code>.
 
 <H2>See also</H2>
 <table>


### PR DESCRIPTION
Change Options JVM screen page to mention the environment variable used
when reading the file .ZAP_JVM.properties.

Part of zaproxy/zaproxy#4004 - zap.bat should use %USERPROFILE% instead
of %HOMEDRIVE%%HOMEPATH%