### PR TITLE
Document how array parameters are identified

### DIFF
--- a/src/help/zaphelp/contents/ui/dialogs/addalert.html
+++ b/src/help/zaphelp/contents/ui/dialogs/addalert.html
@@ -43,7 +43,10 @@ A pull down field which allows you to specify how confident you are in the valid
 
 <H3>Parameter</H3>
 A pull down field which allows you to specify which parameter the issue is associated with.<br/>
-The field is prepopulated with any URL and FORM parameters found, but you can also enter your own parameter name. 
+The field is prepopulated with any URL and FORM parameters found, but you can also enter your own parameter name.<br />
+Array parameters (in URL query component and <code>x-www-form-urlencoded</code> request body) are identified with its index. For
+example, for a request containing <code>choices[]=ChoiceA&amp;choices[]=ChoiceB</code> the first parameter would be identified
+as <code>choices[0]</code> and the second as <code>choices[1]</code>.
 
 <H3>Description</H3>
 A general description of the type of issue found.<br/>

--- a/src/help/zaphelp/contents/ui/dialogs/options/ascaninput.html
+++ b/src/help/zaphelp/contents/ui/dialogs/options/ascaninput.html
@@ -54,6 +54,9 @@ which are not supported by default.
 
 <p>
 This screen also allows you to configure the parameters which will be ignored by the active scanner.
+<br />
+Refer to <code>Parameter</code> section in <a href="../addalert.html">Add Alert</a> dialogue for more details about the
+parameter names.
 
 <H2>See also</H2>
 <table>


### PR DESCRIPTION
Update pages Add Alert dialog and Active Scan Input Vectors to document
how the array parameters are identified.

Part of zaproxy/zaproxy#2496 - ZAP only report the first alert in array