### PR TITLE
Fix typo in Local Proxies page

### DIFF
--- a/src/help/zaphelp/contents/ui/dialogs/options/localproxy.html
+++ b/src/help/zaphelp/contents/ui/dialogs/options/localproxy.html
@@ -9,7 +9,7 @@ Options Local Proxies screen
 <BODY BGCOLOR="#ffffff">
 <H1>Options Local Proxies screen</H1>
 <p>
-The Options Connection screen allows you to configure the addresses and ports 
+This screen allows you to configure the addresses and ports 
 on which ZAP accepts incoming connections.<br/>
 
 <H2>Local Proxy</H2>


### PR DESCRIPTION
Change Options Local Proxies screen page to correct the mention to the
screen itself (was using the name of other screen).