### PR TITLE
Tweak Spider options page

### DIFF
--- a/src/help/zaphelp/contents/ui/dialogs/options/spider.html
+++ b/src/help/zaphelp/contents/ui/dialogs/options/spider.html
@@ -19,9 +19,9 @@
 	deeper than this level are not fetched and parsed by the spider.
 	<p>
 		The depth is calculated starting from the seeds, so, if a Spider scan
-		starts with only a single URL (eg. Spider URL), the depth is
+		starts with only a single URL (eg. URL manually specified), the depth is
 		calculated from this one. However, if the scan starts with multiple
-		seeds (eg. Spider site), a resource is processed if it's depth
+		seeds (eg. recurse and Sites tree node with children), a resource is processed if it's depth
 		relative to <i>any</i> of the seeds is less than the defined one.
 	</p>
 


### PR DESCRIPTION
Change Options Spider screen page to use current functionality as
examples when describing the crawl depth calculation, the menus Spider
URL and Spider site are no longer enabled/available.