### PR TITLE
Document potential breaking change in API views

### DIFF
--- a/src/help/zaphelp/contents/releases/2_8_0.html
+++ b/src/help/zaphelp/contents/releases/2_8_0.html
@@ -67,6 +67,12 @@ instead of:
 }
 </code></pre></blockquote>
 
+<H3>VIEW core / alerts</H3>
+The view will now validate the risk ID, returning an error (ILLEGAL_PARAMETER) if not valid.
+
+<H3>VIEW core / numberOfAlerts</H3>
+The view will now validate the risk ID, returning an error (ILLEGAL_PARAMETER) if not valid.
+
 <H2>ZAP API Changed Endpoints:</H2>
 
 <H2>ZAP API New Endpoints:</H2>


### PR DESCRIPTION
Change Release 2.8.0 page to mention that the API core views alerts and
numberOfAlerts will now require a valid risk ID.

Part of zaproxy/zaproxy#4113 - Validate risk ID in core API views