### PR TITLE
Document change to -dir command line argument

### DIFF
--- a/src/help/zaphelp/contents/cmdline.html
+++ b/src/help/zaphelp/contents/cmdline.html
@@ -31,7 +31,7 @@ ZAP supports the following command line options:
 <tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td>-daemon</td><td>Starts ZAP in daemon mode, ie without a UI</td></tr>
 <tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td>-config &lt;kvpair&gt;</td><td>Overrides the specified key=value pair in the configuration file. <code>-config</code> command line options are applied in the order they are specified.</td></tr>
 <tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td>-configfile &lt;path&gt;</td><td>Overrides the key=value pairs with those in the specified properties file</td></tr>
-<tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td>-dir &lt;dir&gt;</td><td>Uses the specified directory instead of the default one</td></tr>
+<tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td>-dir &lt;dir&gt;</td><td>Uses the specified directory as home directory, instead of the default one. To prevent add-ons (inadvertently) use/override core files ZAP will not start (and show an error) if the home and the installation directories are the same.</td></tr>
 <tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td>-installdir &lt;dir&gt;</td><td>Overrides the code that detects where ZAP has been installed with the specified directory</td></tr>
 <tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td>-h</td><td>Shows all of the command line options available, including those added by add-ons</td></tr>
 <tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td>-help</td><td>The same as -h</td></tr>

--- a/src/help/zaphelp/contents/releases/2_8_0.html
+++ b/src/help/zaphelp/contents/releases/2_8_0.html
@@ -9,6 +9,11 @@
 <BODY BGCOLOR="#ffffff">
 <H1>Release 2.8.0</H1>
 
+<H2>Command Line Changes</H2>
+<h3>-dir &lt;dir&gt;</h3>
+To prevent add-ons (inadvertently) use/override core files ZAP will no longer start (and show an error) if the home and the
+installation directories are the same.
+
 <H2>Enhancements</H2>
 
 <H2>Bug fixes</H2>


### PR DESCRIPTION
Change pages Command Line and Release 2.8.0 to document the change to
-dir command line argument.

Part of zaproxy/zaproxy#4226 - Prevent use of install dir as home dir