### PR TITLE
Update description of spider option max depth

### DIFF
--- a/src/help/zaphelp/contents/ui/dialogs/options/spider.html
+++ b/src/help/zaphelp/contents/ui/dialogs/options/spider.html
@@ -16,7 +16,8 @@
 	<h3>Maximum depth to crawl</h3>
 	The parameter defines the maximum depth in the crawling process where a
 	page must be found in order for it to be processed. Resources found
-	deeper than this level are not fetched and parsed by the spider.
+	deeper than this level are not fetched and parsed by the spider. The value
+	zero means unlimited depth.
 	<p>
 		The depth is calculated starting from the seeds, so, if a Spider scan
 		starts with only a single URL (eg. URL manually specified), the depth is


### PR DESCRIPTION
Change Options Spider screen page to mention the meaning of zero value
for maximum depth to crawl.

Part of zaproxy/zaproxy#4265 - Unable to spider with unlimited depth