### PR TITLE
Fix typos reported in Crowdin

### DIFF
--- a/src/help/zaphelp/contents/ui/dialogs/enc_dec.html
+++ b/src/help/zaphelp/contents/ui/dialogs/enc_dec.html
@@ -12,7 +12,7 @@ Encode / Decode / Hash dialog
 This allows you to encode, decode or hash text.
 
 <H2>Common fields</H2>
-The dialog has one fields that is common to all of the tabs:
+The dialog has one field that is common to all of the tabs:
 
 <H3>Text to be encoded/decoded/hashed</H3>
 This field is for the text that you want to be encoded, decoded or hashed.<br/>

--- a/src/help/zaphelp/contents/ui/dialogs/options/dynsslcert.html
+++ b/src/help/zaphelp/contents/ui/dialogs/options/dynsslcert.html
@@ -37,7 +37,7 @@ Dynamic SSL Certificates
 
 <H2>ZAP Root CA certificate</H2>
 <p>
-	Imagine your're visiting multiple SSL protected sites. Every time your
+	Imagine you're visiting multiple SSL protected sites. Every time your
 	browser connects such a site, a new SSL certificate is created.
 	But, these certificates are not trusted by anyone (because self created by ZAP).
 	In other words, your browser will not accept such certificates in the first place.
@@ -205,7 +205,7 @@ And yes, that example will work - its the Superfish certificate!
 	certificate (copy it to you target computer) and double click the .CER file. 
 	When doing so, the regular Windows wizard for certificate installation
 	assistance is poping up.
-	In the this wizard manually choose the certificate store. Do NOT let
+	In this wizard manually choose the certificate store. Do NOT let
 	Windows choose automatically the certificate store.
 	Choose 'trusted root certificates' as store and finalize the wizard.
 </p>


### PR DESCRIPTION
Fix typos in the pages "Dynamic SSL Certificates" and "Encode / Decode /
Hash dialog".
Reported by: https://crowdin.com/profile/andresitorresm