### PR TITLE
Update label of API option

### DIFF
--- a/src/help/zaphelp/contents/ui/dialogs/options/api.html
+++ b/src/help/zaphelp/contents/ui/dialogs/options/api.html
@@ -15,7 +15,7 @@ This screen allows you to configure the <a href="../../../start/concepts/api.htm
 
 If enabled then the API is available to all machines that are able to use ZAP as a proxy.<br/>
 
-<H3>UI Enabled</H3>
+<H3>Web UI Enabled</H3>
 
 If enabled then the API Web UI is available to all machines that are able to use ZAP as a proxy. 
 To access the API Web UI point your browser to the host and port that ZAP is listening on.<br/>


### PR DESCRIPTION
Change Options API screen page to use the new label of the option that
enables the Web UI.

Part of zaproxy/zaproxy#4313 - Tweak label of API option