### PR TITLE
Update Edit Menu & Options Connection Screen Entries

### DIFF
--- a/src/help/zaphelp/contents/ui/dialogs/man_req.html
+++ b/src/help/zaphelp/contents/ui/dialogs/man_req.html
@@ -30,7 +30,7 @@ This changes the display so that separate panes are used for the header and body
 This changes the display so that the header and body are shown in one pane.<br> 
 
 <H3><img src="../../images/fugue/cookie.png" align="bottom" width="16" height="16" />&nbsp; Use current tracking session</H3>
-See the 'Enable session tracking (Cookie)' menu item in the <a href="../tlmenu/edit.html">Edit menu</a>.<br>  
+See the 'Enable (Global) HTTP State' option in the <a href="./options/connection.html">Options Connection screen</a>.<br>
 
 <H3><img src="../../images/16/118.png" align="bottom" width="16" height="16" />&nbsp; Follow redirect</H3>
 If selected automatically follows any redirects sent to the browser.<br> 

--- a/src/help/zaphelp/contents/ui/dialogs/options/connection.html
+++ b/src/help/zaphelp/contents/ui/dialogs/options/connection.html
@@ -19,8 +19,18 @@ The user agent that ZAP should use when creating HTTP messages (for example, spi
 proxy).
 
 <H3>Single Cookie Request Header</H3>
-Controls whether the ZAP's managed cookies (<a href="../../tlmenu/edit.html">Enable Session Tracking (Cookie)</a>) should be set
+Controls whether the ZAP's managed cookies (Enable (Global) HTTP State) should be set
 on a single "Cookie" request header or multiple "Cookie" request headers, when sending an HTTP request to the server.
+
+<H3>Enable (Global) HTTP State</H3>
+This allows session details stored in cookies to be tracked.<br/>
+This option must be selected to enable the "Use current tracking session" checkbox in the 
+<a href="../../dialogs/resend.html">Resend</a> and <a href="../../dialogs/man_req.html">Manual Request Editor dialogs</a>.<br/>
+Session tracking ensures that any requests are sent with the latest session details.<br/>
+For example you may record a session when logged in as one user and then logout and login as another user.<br/>
+If you resend a request from the first session without session tracking then it will use the cookies from 
+the first session.<br/>
+If you resend the same request with session tracking then it will use the cookies from the second session.
 
 <H3>DNS</H3>
 <h4>TTL Successful Queries</h4>

--- a/src/help/zaphelp/contents/ui/dialogs/options/spider.html
+++ b/src/help/zaphelp/contents/ui/dialogs/options/spider.html
@@ -82,7 +82,7 @@
 	its own cookie jar.
 	<br>This option has low priority, the Spider will respect other (global) options related
 	to the HTTP state. This option is ignored if, for example, the option
-	<a href="../../tlmenu/edit.html">Enable Session Tracking (Cookie)</a> is enabled, when
+	<a href="connection.html">Enable (Global) HTTP State</a> is enabled, when
 	spidering as a <a href="../../../start/concepts/users.html">User</a> or when a
 	<a href="../../../start/concepts/httpsessions.html">HTTP Session</a> is active.
 

--- a/src/help/zaphelp/contents/ui/dialogs/resend.html
+++ b/src/help/zaphelp/contents/ui/dialogs/resend.html
@@ -30,7 +30,7 @@ This changes the display so that separate panes are used for the header and body
 This changes the display so that the header and body are shown in one pane.<br> 
 
 <H3><img src="../../images/fugue/cookie.png" align="bottom" width="16" height="16" />&nbsp; Use current tracking session</H3>
-See the 'Enable session tracking (Cookie)' menu item in the <a href="../tlmenu/edit.html">Edit menu</a>.<br>  
+See the 'Enable (Global) HTTP State' option in the <a href="./options/connection.html">Options Connection screen</a>.<br>
 
 <H3><img src="../../images/16/118.png" align="bottom" width="16" height="16" />&nbsp; Follow redirect</H3>
 If selected automatically follows any redirects sent to the browser.<br> 

--- a/src/help/zaphelp/contents/ui/tlmenu/edit.html
+++ b/src/help/zaphelp/contents/ui/tlmenu/edit.html
@@ -9,27 +9,13 @@ The Edit menu
 <BODY BGCOLOR="#ffffff">
 <H1>The Edit menu</H1>
 This menu handles finding strings in specific tabs, searching for strings across all 
-requests and responses and managing session tracking.
+requests and responses, changing ZAP's mode, and managing forced user mode.
+
+<H3>ZAP Mode</H3>
+This allows you to change the current <a href="../../start/concepts/modes.html">mode</a>.
 
 <H3>Find...</H3>
 This opens the <a href="../dialogs/find.html">Find dialog</a> which allows you to find a string in the currently selected window.<br/>
-
-<H3>Enable Session Tracking (Cookie)</H3>
-This allows session details stored in cookies to be tracked.<br/>
-This option must be selected to enable the "Use current tracking session" checkbox
-in the <a href="../dialogs/resend.html">Resend</a> and 
-<a href="../dialogs/man_req.html">Manual Request Editor dialogs</a>. <br/>
-Session tracking ensures that any requests are sent with the latest session
-details.<br/>
-For example you may record a session when logged in as one user and then logout
-and login as another user.<br/>
-If you resend a request from the first session without
-session tracking then it will use the cookies from the first session.<br/>
-If you resend the same request with session tracking then it will use the
-cookies from the second session.
-
-<H3>Reset Session State</H3>
-This clears the session tracking.<br/>
 
 <H3>Search...</H3>
 This selects the <a href="../tabs/search.html">Search tab</a> which allows you to search for regular expressions
@@ -46,6 +32,12 @@ This selects the previous occurrence of the last string searched for.<br/>
 The relevant message will be selected in the Search tab and the string will be displayed
 and highlighted in the <a href="../tabs/request.html">Request</a> or
 <a href="../tabs/response.html">Response</a> tab as appropriate.
+
+<H3>Enable / Disable Forced User Mode</H3>
+This switches forced user mode on and off.<br/>
+The menu item is only enabled when you have defined a forced user for at least one 
+<a href="../../start/concepts/contexts.html">context</a>, which can be done via the 
+<a href="../dialogs/session/contexts.html">Session Contexts</a> dialog.
 
 <p>
 Note that <a href="../../start/concepts/addons.html">add-ons</a> can add additional menu items.

--- a/src/help/zaphelp/contents/ui/tlmenu/tlmenu.html
+++ b/src/help/zaphelp/contents/ui/tlmenu/tlmenu.html
@@ -14,7 +14,8 @@ By default the following top level menu items will be present:<br/>
 <tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td>
 <a href="file.html">File menu</a> </td><td>This handles the current session</td></tr>
 <tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td>
-<a href="edit.html">Edit menu</a> </td><td>This handles searching for strings and managing session tracking.</td></tr>
+<a href="edit.html">Edit menu</a> </td><td>This handles finding strings in specific tabs, searching for 
+strings across all requests and responses, changing ZAP's mode, and managing forced user mode</td></tr>
 <tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td>
 <a href="view.html">View menu</a> </td><td> This handles the display options</td></tr>
 <tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td>


### PR DESCRIPTION
Per zaproxy/zaproxy#1161 (comment)

- Updated Edit and Top Level menu help content so that it covers the current menu items
- Updated Options Connection screen, manual request, resend, and spider help content so that it covers "Enable (Global) HTTP State"

Fixes zaproxy/zaproxy#4280