### PR TITLE
Add urls context API view to release notes

### DIFF
--- a/src/help/zaphelp/contents/releases/2_8_0.html
+++ b/src/help/zaphelp/contents/releases/2_8_0.html
@@ -82,6 +82,9 @@ The view will now validate the risk ID, returning an error (ILLEGAL_PARAMETER) i
 
 <H2>ZAP API New Endpoints:</H2>
 
+<H3>VIEW context / urls</H3>
+Lists the URLs accessed through/by ZAP, that belong to the context with the given name.
+
 <H3>VIEW script / globalVar</H3>
 Gets the value of the global variable with the given key. Returns an API error (DOES_NOT_EXIST) if no value was previously set.
 


### PR DESCRIPTION
Change Release 2.8.0 page to add the new context API view that allows to
obtain the URLs of a context.

Part of zaproxy/zaproxy#4364 - Allow to obtain context's URLs through
the API