### PR TITLE
Add snapshotSession API action to release notes

### DIFF
--- a/src/help/zaphelp/contents/releases/2_8_0.html
+++ b/src/help/zaphelp/contents/releases/2_8_0.html
@@ -80,6 +80,9 @@ The view will now validate the risk ID, returning an error (ILLEGAL_PARAMETER) i
 
 <H2>ZAP API Changed Endpoints:</H2>
 
+<H3>ACTION core / snapshotSession</H3>
+Added optional parameters <code>name</code> and <code>overwrite</code>, to allow to specify a name and overwrite existing files.
+
 <H2>ZAP API New Endpoints:</H2>
 
 <H3>VIEW script / globalVar</H3>


### PR DESCRIPTION
Change Release 2.8.0 page to add the API core action "snapshotSession",
now allows to specify a name and overwrite files.

Part of zaproxy/zaproxy#4365 - Allow to specify a name for session
snapshot through the API