### PR TITLE
Update Break Point dialog page

### DIFF
--- a/src/help/zaphelp/contents/ui/dialogs/addbreak.html
+++ b/src/help/zaphelp/contents/ui/dialogs/addbreak.html
@@ -3,21 +3,33 @@
 <HEAD>
 <META HTTP-EQUIV="Content-Type" CONTENT="text/html; charset=utf-8">
 <TITLE>
-Add Break Point dialog
+Add/Edit Break Point dialog
 </TITLE>
 </HEAD>
 <BODY BGCOLOR="#ffffff">
-<H1>Add Break Point dialog</H1>
+<H1>Add/Edit Break Point dialog</H1>
 <p>
-This allows you to set a 
-<a href="../../start/concepts/breakpoints.html">break point</a> on a URL.
-</p>
+This dialogue allows you to add and edit <a href="../../start/concepts/breakpoints.html">HTTP break points</a>.
+
 <p>
-The break point is defined via a regex expression.<br/>
-If you visit a URL which matches this 
-expression then ZAP will intercept it and allow you to change either the request and/or the
-response.
-</p>
+A break point is defined by the following fields:
+
+<ul>
+	<li><strong>Location</strong> - where the <code>String</code> is checked in the
+		HTTP message: <code>URL</code>, <code>Request Header</code>, <code>Request Body</code>,
+		<code>Response Header</code>, or <code>Response Body</code>.</li>
+	<li><strong>Match</strong> - how the <code>String</code> is interpreted, <code>Regex</code>
+		or <code>Contains</code>, for regular expression or exact match, respectively, in the <code>Location</code>.
+		The regular expression does not need to match the whole content of the <code>Location</code>.</li>
+	<li><strong>String</strong> - the string that triggers the break point.</li>
+	<li><strong>Inverse</strong> - if the result of the <code>Match</code> should be
+		the inverse.</li>
+	<li><strong>Ignore case</strong> - if the case of the <code>String</code> should be
+		ignored.</li>
+</ul>
+
+If you proxy a HTTP message that matches a break point then ZAP will intercept it and allow you to change either the request
+and/or the response.
 
 <H2>Accessed via</H2>
 <table>

--- a/src/help/zaphelp/index.xml
+++ b/src/help/zaphelp/index.xml
@@ -15,7 +15,7 @@
     <indexitem text="add-ons" target="start.concepts.addons"/>
     <indexitem text="add-ons" target="addon.introduction"/>
     <indexitem text="add alert dialog" target="ui.dialogs.addalert" />
-    <indexitem text="add break point dialog" target="ui.dialogs.addbreak" />
+    <indexitem text="add/edit break point dialog" target="ui.dialogs.addbreak" />
     <indexitem text="add note dialog" target="ui.dialogs.addnote" />
     <indexitem text="alerts tab" target="ui.tabs.alerts" />
     <indexitem text="alerts" target="start.concepts.alerts" />

--- a/src/help/zaphelp/toc.xml
+++ b/src/help/zaphelp/toc.xml
@@ -78,7 +78,7 @@
       <tocitem text="The Dialogs" target="ui.dialogs">
          <tocitem text="Active Scan" target="ui.dialogs.advascan"/>
          <tocitem text="Add Alert" target="ui.dialogs.addalert"/>
-         <tocitem text="Add Break Point" target="ui.dialogs.addbreak"/>
+         <tocitem text="Add/Edit Break Point" target="ui.dialogs.addbreak"/>
          <tocitem text="Add Note" target="ui.dialogs.addnote"/>
          <tocitem text="Encode/Decode/Hash" target="ui.dialogs.enc_dec"/>
          <tocitem text="Find" target="ui.dialogs.find"/>


### PR DESCRIPTION
Rename the page (title) to Add/Edit Break Point dialog, it allows to add
and edit the break point, also describe the fields that compose the HTTP
break point.
Update TOC and index to reflect the rename of the page.

Related to zaproxy/zaproxy#4477 - Enable help in Add/Edit Break Point
dialogue