### PR TITLE
Mention Contexts tree in Sites tab page

### DIFF
--- a/src/help/zaphelp/contents/ui/tabs/sites.html
+++ b/src/help/zaphelp/contents/ui/tabs/sites.html
@@ -8,109 +8,114 @@ Sites tab
 </HEAD>
 <BODY BGCOLOR="#ffffff">
 <H1>Sites tab</H1>
-<p>
-The Sites tab shows all of the URLs visited in a tree structure. <br/>
+The sites tab contains two trees, one for <a href="../../start/concepts/contexts.html">contexts</a> and the other for the sites accessed by/through ZAP.
+
+<h2>Contexts tree</h2>
+Shows the contexts contained in the current session. It allows to quickly access its properties by double clicking them and
+provides access to other functionality through the component's context menu.
+
+<h2>Sites tree</h2>
+Shows all of the URLs visited in a tree structure. <br/>
 You can select any of the nodes in the tree to display the request and response for that URL 
 in the relevant tabs.<br/>
-</p>
 
-<H2>Right click menu</H2>
+<H3>Right click menu</H3>
 Right clicking on a node will bring up a menu which will allow you to:
 
-<H3>Attack</H3>
+<H4>Attack</H4>
 The Attack menu has the following submenus:
 
-<H4>Active Scan...</H4>
+<H5>Active Scan...</H5>
 This will launch the <a href="../dialogs/advascan.html">Active Scan</a> dialog which allows you to initiate an 
 <a href="../../start/concepts/ascan.html">active scan</a> with the starting point set to the request you selected.<br/>
 
-<H4>Spider...</H4>
+<H5>Spider...</H5>
 This will launch the <a href="../dialogs/spider.html">Spider</a> dialog which allows you to initiate the 
 <a href="../../start/concepts/spider.html">spider</a> with the starting point set to the request you selected.<br/>
 
-<H3>Include in Context</H3>
+<H4>Include in Context</H4>
 This menu allows you to include the selected nodes and all of their subordinates in the specified
 <a href="../../start/concepts/contexts.html">context</a>.<br/>
 You also have the option to create a new context.<br/>
 The <a href="../dialogs/session/contexts.html">Session Contexts</a> dialog will be displayed to
 allow you to make any additional changes.
 
-<H3>Exclude from Context</H3>
+<H4>Exclude from Context</H4>
 This menu allows you to exclude the selected nodes and all of their subordinates from the specified
 <a href="../../start/concepts/contexts.html">context</a>.<br/>
 The <a href="../dialogs/session/contexts.html">Session Contexts</a> dialog will be displayed to
 allow you to make any additional changes.
 
-<H3>Flag as context</H3>
+<H4>Flag as context</H4>
 This menu has the following submenus for each of the 
 <a href="../../start/concepts/contexts.html">contexts</a> you have defined:
 
-<H4><i>Context name</i> Form-based Auth Login request</H4>
+<H5><i>Context name</i> Form-based Auth Login request</H5>
 This identifies the specified node as a login request for the specified context.<br/>
 You may only have one node identified as such in any one context.<br/> 
 The <a href="../dialogs/session/context-auth.html">Session Context Authentication</a> screen will be displayed to
 allow you to make any additional changes.
 
-<H4><i>Context name</i> Data driven node</H4>
+<H5><i>Context name</i> Data driven node</H5>
 This identifies the specified node as <a href="../../start/concepts/ddc.html">Data driven content</a> for the specified context.<br/>
 The <a href="../dialogs/session/context-struct.html">Session Context Structure</a> screen will be displayed to
 allow you to make any additional changes.
 
-<H3>Exclude from</H3>
+<H4>Exclude from</H4>
 This menu has the following submenus:
 
-<H4>Proxy</H4>
+<H5>Proxy</H5>
 This will exclude the selected nodes from the proxy. They will still be proxied via ZAP but will not be shown 
 in any of the tabs.<br/>
 This can be used to ignore URLs that you know are not relevant to the system you are currently testing.<br/>
 The nodes can be included again via the <a href="../dialogs/session/sessprop.html">Session Properties</a> dialog   
 
-<H4>Scanner</H4>
+<H5>Scanner</H5>
 This will prevent the selected nodes from being actively scanned.<br/>
 The nodes can be included again via the <a href="../dialogs/session/sessprop.html">Session Properties</a> dialog   
 
-<H4>Spider</H4>
+<H5>Spider</H5>
 This will prevent the selected nodes from being spidered.<br/>
 The nodes can be included again via the <a href="../dialogs/session/sessprop.html">Session Properties</a> dialog   
 
-<H3>Delete</H3>
+<H4>Delete</H4>
 This will remove the node and all of its children from ZAP.<br/>
 However they can be added back in, to prevent this use the 'Exclude from' menus. 
 
-<H3>Break...</H3>
+<H4>Break...</H4>
 This will bring up a new window which will allow you to set a 
 <a href="../../start/concepts/breakpoints.html">break point</a> on that URL.<br/>
 The break point is defined via a regular expression. If you visit a URL which matches this 
 expression then ZAP will intercept it and allow you to change either the request and/or the
 response.
 
-<H3>Alerts for this node</H3>
+<H4>Alerts for this node</H4>
 If the URL selected has <a href="../../start/concepts/alerts.html">alerts</a> associated with it then 
 they will be listed under this menu.<br>
 Selecting one of the alerts will cause it to be displayed.
 
-<H3>Open/Resend with Request Editor...</H3>
+<H4>Open/Resend with Request Editor...</H4>
 This will bring up the
 <a href="../dialogs/man_req.html">Manual Request Editor dialog</a> which allows you to  
 resend the request after making any changes to it that you want to.
 
-<H3>New Alert...</H3>
+<H4>New Alert...</H4>
 This will bring up the
 <a href="../dialogs/addalert.html">Add Alert dialog</a> which allows you to manually record a new  
 <a href="../../start/concepts/alerts.html">alert</a> against this request.
 
-<H3>Show in History tab</H3>
+<H4>Show in History tab</H4>
 This will show the selected node in the <a href="history.html">History tab</a>.
 
-<H3>Open URL in Browser</H3>
+<H4>Open URL in Browser</H4>
 This will open the URL of the selected node in your default browser.
 
-<H3>Generate anti CSRF test form</H3>
+<H4>Generate anti CSRF test form</H4>
 This will open a URL which will give you a generated form for testing for CSRF issues.<br>
 It will only be enabled for POST requests, if the API is enabled and if Java supports the opening of URLs 
 in a browser on your platform. 
 
-<H3>Refresh Sites tree</H3>
+<H4>Refresh Sites tree</H4>
 Occasionally the Sites tree can be displayed incorrectly - this option will redraw it.
 
 <H2>See also</H2>


### PR DESCRIPTION
Change Sites tab to mention the Contexts tree.
Tweak existing headers to be under the Sites tree entry.