### PR TITLE
Mention how regexes are checked for contexts

### DIFF
--- a/src/help/zaphelp/contents/start/concepts/contexts.html
+++ b/src/help/zaphelp/contents/start/concepts/contexts.html
@@ -19,6 +19,8 @@ that makes up the system you are testing, and set them in scope as you test each
 <p>
 Contexts are defined as a set of regular expressions (regexs) which are applied to all of the URLs in the
 <a href="../../ui/tabs/sites.html">Sites tab</a>.<br/>
+<strong>Note:</strong> The regular expressions must match the whole URL.
+<p>
 You can configure contexts via:
 <ul>
 <li>Right click menu items in the in the Sites or History tab</li>

--- a/src/help/zaphelp/contents/ui/dialogs/session/contexts.html
+++ b/src/help/zaphelp/contents/ui/dialogs/session/contexts.html
@@ -18,14 +18,16 @@ There is a set of screens for each context you define.
 <H3>Top screen</H3>
 This allows you to set the context name and description.
 
-<H3>Include in context</H3>
+<H3>Include in Context</H3>
 This allows you to manage the URLs which will be included in the context.<br/>
 URLs which dont match any of the regexs will not be included in the context.
+<br><strong>Note:</strong> The regular expressions must match the whole URL.
 
-<H3>Exclude from context</H3>
+<H3>Exclude from Context</H3>
 This allows you to manage the URLs which will be excluded from the context.<br/>
 You only need to specify regexs for URLs that you do not want to include but which match one or more
 of the 'include' regexes.
+<br><strong>Note:</strong> The regular expressions must match the whole URL.
 
 <H3><a name="struct">Structure</a></H3>
 See the <a href="context-struct.html">Session Context Structure screen</a>.


### PR DESCRIPTION
Update pages Contexts and Session Context screens to specify how the
regular expression is checked against the URL (must match). Also,
capitalise the names of the panels in the Session Context screens.

---
Pointed out in the IRC channel some time ago.