### PR TITLE
Add copy session context menu to HTTP Sessions tab

### DIFF
--- a/src/help/zaphelp/contents/ui/tabs/httpsessions.html
+++ b/src/help/zaphelp/contents/ui/tabs/httpsessions.html
@@ -30,6 +30,8 @@
 	<p>Each of the entries in the Sessions table can be right clicked,
 		which activates the Popup Menu, with the following options:</p>
 	<ul>
+		<li>Copy Session Token Value to Clipboard - copies the value of the
+		selected session to the clipboard.</li>
 		<li>Remove Session - deletes the session</li>
 		<li>Set as active (available only on non-active sessions) - marks
 			this session as active. If any session was previously set as active,


### PR DESCRIPTION
Change HTTP Sessions tab page to document the pop up menu item that
allows to copy the value of the session to the clipboard.

Part of zaproxy/zaproxy#1655 - Copy Session Token from Http Sessions tab
to clipboard