### PR TITLE
Update help for JSON-based authentication

### DIFF
--- a/src/help/zaphelp/contents/start/concepts/authentication.html
+++ b/src/help/zaphelp/contents/start/concepts/authentication.html
@@ -105,6 +105,22 @@
 	authentication.</p>
 	
 	<h3>
+		<a name="jsonBased">JSON-Based Authentication</a>
+	</h3>
+	<p>
+		This method is used for websites / webapps where authentication is
+		done by submitting a JSON object to a 'login url' using a 'username/password'
+		pair of authentication credentials.
+		Re-authentication is possible. Configuration can be done using the <a
+			href="../../ui/dialogs/session/contexts.html#auth">Session
+			Contexts Dialog</a> or using the contextual PopupMenu: <i>Flag as...
+			JSON-Based Authentication Login Request</i>.
+	</p>
+	<p>When using this authentication method, configuring a User for the context requires
+	setting up the <i>username/password</i> pair of credentials that are used for the
+	authentication.</p>
+	
+	<h3>
 		<a name="httpAuth">HTTP/NTLM Authentication</a>
 	</h3>
 	<p>

--- a/src/help/zaphelp/contents/ui/dialogs/session/context-auth.html
+++ b/src/help/zaphelp/contents/ui/dialogs/session/context-auth.html
@@ -28,6 +28,19 @@ a HTTP GET, otherwise an HTTP POST is used. The credentials themselves
 are configured in the <a href="contexts.html#users">Users</a> tab. <small>Read  
 <a href="../../../start/concepts/authentication.html#formBased">more</a>...</small> 
 
+<h4>JSON-Based Authentication</h4>
+To configure this authentication method, you need to supply the <b>login url</b>, to which the login
+request is performed, the <b>JSON object</b> (POST data, <code>application/json</code>), and identify
+the <b>parameters</b> used to supply the 'username' and 'password'.  The credentials themselves
+are configured in the <a href="contexts.html#users">Users</a> tab. <small>Read 
+<a href="../../../start/concepts/authentication.html#jsonBased">more</a>...</small>
+<br>Examples of POST data:
+<ul>
+	<li><code>{"username":"{%username%}","password":"{%password%}"}</code></li>
+	<li><code>{"user":{"mail":"{%username%}","password":"{%password%}"}}</code></li>
+</ul>
+where <code>{%username%}</code> and <code>{%password%}</code> indicate where the authentication credentials are set.
+
 <h4>HTTP/NTLM Authentication</h4>
 To configure this authentication method, you need to supply the <b>hostname</b> and the <b>port</b> of the server
 the authentication is done with and the <b>realm</b> the credentials apply to. The credentials themselves

--- a/src/help/zaphelp/contents/ui/tabs/history.html
+++ b/src/help/zaphelp/contents/ui/tabs/history.html
@@ -81,6 +81,12 @@ You may only have one node identified as such in any one context.<br/>
 The <a href="../dialogs/session/context-auth.html">Session Context Authentication</a> screen will be displayed to
 allow you to make any additional changes.
 
+<H4><i>Context name</i> JSON-based Auth Login request</H4>
+This identifies the specified node as a login request for the specified context.<br/>
+You may only have one node identified as such in any one context.<br/> 
+The <a href="../dialogs/session/context-auth.html">Session Context Authentication</a> screen will be displayed to
+allow you to make any additional changes.
+
 <H4><i>Context name</i> Data driven node</H4>
 This identifies the specified node as <a href="../../start/concepts/ddc.html">Data driven content</a> for the specified context.<br/>
 The <a href="../dialogs/session/context-struct.html">Session Context Structure</a> screen will be displayed to

--- a/src/help/zaphelp/contents/ui/tabs/search.html
+++ b/src/help/zaphelp/contents/ui/tabs/search.html
@@ -65,6 +65,12 @@ You may only have one node identified as such in any one context.<br/>
 The <a href="../dialogs/session/context-auth.html">Session Context Authentication</a> screen will be displayed to
 allow you to make any additional changes.
 
+<H4><i>Context name</i> JSON-based Auth Login request</H4>
+This identifies the specified node as a login request for the specified context.<br/>
+You may only have one node identified as such in any one context.<br/> 
+The <a href="../dialogs/session/context-auth.html">Session Context Authentication</a> screen will be displayed to
+allow you to make any additional changes.
+
 <H4><i>Context name</i> Data driven node</H4>
 This identifies the specified node as <a href="../../start/concepts/ddc.html">Data driven content</a> for the specified context.<br/>
 The <a href="../dialogs/session/context-struct.html">Session Context Structure</a> screen will be displayed to

--- a/src/help/zaphelp/contents/ui/tabs/sites.html
+++ b/src/help/zaphelp/contents/ui/tabs/sites.html
@@ -79,6 +79,12 @@ You may only have one node identified as such in any one context.<br/>
 The <a href="../dialogs/session/context-auth.html">Session Context Authentication</a> screen will be displayed to
 allow you to make any additional changes.
 
+<H4><i>Context name</i> JSON-based Auth Login request</H4>
+This identifies the specified node as a login request for the specified context.<br/>
+You may only have one node identified as such in any one context.<br/> 
+The <a href="../dialogs/session/context-auth.html">Session Context Authentication</a> screen will be displayed to
+allow you to make any additional changes.
+
 <H5><i>Context name</i> Data driven node</H5>
 This identifies the specified node as <a href="../../start/concepts/ddc.html">Data driven content</a> for the specified context.<br/>
 The <a href="../dialogs/session/context-struct.html">Session Context Structure</a> screen will be displayed to


### PR DESCRIPTION
Change help pages Authentication and Session Context Authentication to
mention the JSON-based authentication method.
Mention the "flag" pop up menu item in tabs History, Search, and Sites.

Part of zaproxy/zaproxy#2439 - Configure Authentication with Json object