### PR TITLE
Add listTypes script API view to release notes

### DIFF
--- a/src/help/zaphelp/contents/releases/2_8_0.html
+++ b/src/help/zaphelp/contents/releases/2_8_0.html
@@ -98,6 +98,9 @@ Gets the value of the global variable with the given key. Returns an API error (
 <H3>VIEW script / globalVars</H3>
 Gets all the global variables (key/value pairs).
 
+<H3>VIEW script / listTypes</H3>
+Lists the script types available.
+
 <H3>VIEW script / scriptVar</H3>
 Gets the value of the variable with the given key for the given script. Returns an API error (DOES_NOT_EXIST) if no script with the given name exists or if no value was previously set.
 


### PR DESCRIPTION
Change Release 2.8.0 page to add the new script API view that allows to
list the script types available.

Part of zaproxy/zaproxy#4688 - Allow to view script types through the
API