### PR TITLE
Tweak Spider/Active Scan dialogues' labels

### DIFF
--- a/src/help/zaphelp/contents/ui/dialogs/advascan.html
+++ b/src/help/zaphelp/contents/ui/dialogs/advascan.html
@@ -18,10 +18,10 @@ If the starting point is in one or more <a href="../../start/concepts/contexts.h
 If that context has any <a href="../../start/concepts/users.html">Users</a> defined then you will be able to select one of them.<br>
 If you select one of the users then the active scan will be performed as that user, with ZAP (re)authenticating as that user whenever necessary.
 <br><br>
-If you select 'recurse' then all of the nodes underneath the one selected will also be scanned.<br>
+If you select 'Recurse' then all of the nodes underneath the one selected will also be scanned.<br>
 Custom input vectors are only supported if this option is not selected.
 <br><br>
-If you select 'Show advanced options' then the following tabs will be shown which provide fine grain control over the active scanning process.
+If you select 'Show Advanced Options' then the following tabs will be shown which provide fine grain control over the active scanning process.
 <br><br>
 Clicking on the 'Reset' button will reset all of the options to their default values. 
 
@@ -32,7 +32,7 @@ Clicking on the 'Reset' button will reset the input vectors to the default optio
 
 <H3>Custom Vectors</H3>
 The Custom Vectors tab allows you specify specific locations in the request to attack.<br> 
-Custom Vectors are only available if the 'recurse' option on the first tab is not selected.<br>
+Custom Vectors are only available if the 'Recurse' option on the first tab is not selected.<br>
 To add custom input vectors highlight the characters you want to attack in the request and click the 'Add' button.<br>
 You can add as many custom input vectors as you want.<br>
 To remove custom input vectors highlight any of the selected characters and click the 'Remove' button.<br>

--- a/src/help/zaphelp/contents/ui/dialogs/spider.html
+++ b/src/help/zaphelp/contents/ui/dialogs/spider.html
@@ -17,12 +17,12 @@ If the starting point is in one or more <a href="../../start/concepts/contexts.h
 If that context has any <a href="../../start/concepts/users.html">Users</a> defined then you will be able to select one of them.<br>
 If you select one of the users then the spider will be performed as that user, with ZAP (re)authenticating as that user whenever necessary.
 <br><br>
-If you select 'recurse' then all of the nodes underneath the one selected will also be used to seed the spider.
+If you select 'Recurse' then all of the nodes underneath the one selected will also be used to seed the spider.
 <br><br>
 If you select 'Spider Subtree Only' the spider will only access resources that are under the starting point (URI).
 When evaluating if a resource is found within the specified subtree, the spider considers only the scheme, host, port, and path components of the URI.
 <br><br>
-If you select 'Show advanced options' then the following tab will be shown which provide fine grain control over the spider process.
+If you select 'Show Advanced Options' then the following tab will be shown which provide fine grain control over the spider process.
 <br><br>
 Clicking on the 'Reset' button will reset all of the options to their default values. 
 


### PR DESCRIPTION
Tweak the labels per changes in core, to follow title capitalisation.

Related to zaproxy/zaproxy#4648.