### PR TITLE
Add context API changes to release notes

### DIFF
--- a/src/help/zaphelp/contents/releases/2_8_0.html
+++ b/src/help/zaphelp/contents/releases/2_8_0.html
@@ -84,6 +84,20 @@ The view will now validate the risk ID, returning an error (ILLEGAL_PARAMETER) i
 
 <H2>ZAP API Changed Endpoints:</H2>
 
+<H3>ACTION context / excludeContextTechnologies</H3>
+The action will now accept the string with technologies even if there are spaces before or after the names, for example:
+<blockquote><pre><code>
+os.linux, db.mysql
+</code></pre></blockquote>
+will now be valid.
+
+<H3>ACTION context / includeContextTechnologies</H3>
+The action will now accept the string with technologies even if there are spaces before or after the names, for example:
+<blockquote><pre><code>
+os.linux, db.mysql
+</code></pre></blockquote>
+will now be valid.
+
 <H3>ACTION core / snapshotSession</H3>
 Added optional parameters <code>name</code> and <code>overwrite</code>, to allow to specify a name and overwrite existing files.
 


### PR DESCRIPTION
Change Release 2.8.0 page to mention that context API actions
includeContextTechnologies and excludeContextTechnologies will now
accept a string with spaces between the names and commas.

Part of zaproxy/zaproxy#4767 - Be more lenient when parsing techs
through the API