### PR TITLE
Remove commented TOC/map entries

### DIFF
--- a/src/help/zaphelp/map.jhm
+++ b/src/help/zaphelp/map.jhm
@@ -38,14 +38,6 @@
         <mapID target="start.concepts.users" url="contents/start/concepts/users.html" />
         <mapID target="start.checks" url="contents/start/checks.html" />
         <mapID target="start.pentest" url="contents/pentest/pentest.html" />
-        <!--mapID target="vulns.vuln" url="contents/vulns/vulnerabilities.html" /-->
-        <!--mapID target="vulns.csrf" url="contents/vulns/csrf.html" /-->
-        <!--mapID target="vulns.idor" url="contents/vulns/idor.html" /-->
-        <!--mapID target="vulns.leak" url="contents/vulns/leak.html" /-->
-        <!--mapID target="vulns.nossl" url="contents/vulns/nossl.html" /-->
-        <!--mapID target="vulns.sqli" url="contents/vulns/sqli.html" /-->
-        <!--mapID target="vulns.urla" url="contents/vulns/urla.html" /-->
-        <!--mapID target="vulns.xss" url="contents/vulns/xss.html" /-->
         <mapID target="ui.overview" url="contents/ui/overview.html" />
         <mapID target="ui.topmenu" url="contents/ui/tlmenu/tlmenu.html" />
         <mapID target="ui.toptoolbar" url="contents/ui/tltoolbar.html" />

--- a/src/help/zaphelp/toc.xml
+++ b/src/help/zaphelp/toc.xml
@@ -46,16 +46,6 @@
       <tocitem text="A Simple Penetration Test" target="start.pentest"/>
    </tocitem>
 
-   <!--tocitem text="Common Vulnerabilities" target="vulns.vuln">
-      <tocitem text="Cross Site Request Forgery" target="vulns.csrf"/>
-      <tocitem text="Insecure Direct Object References" target="vulns.idor"/>
-      <tocitem text="Information Leakage / Improper Error Handling" target="vulns.leak"/>
-      <tocitem text="Insecure Communications" target="vulns.nossl"/>
-      <tocitem text="SQL Injection" target="vulns.sqli"/>
-      <tocitem text="Failure to restrict URL access" target="vulns.urla"/>
-      <tocitem text="Cross Site Scripts" target="vulns.xss"/>
-   </tocitem-->
-
    <tocitem text="The User Interface" target="ui.overview">
       <tocitem text="Overview" target="ui.overview"/>
       <tocitem text="The Top Level Menu" target="ui.topmenu"/>

--- a/src/help/zaphelp_ar_SA/map.jhm
+++ b/src/help/zaphelp_ar_SA/map.jhm
@@ -39,14 +39,6 @@
         <mapID target="start.concepts.users" url="contents/start/concepts/users.html" />
         <mapID target="start.checks" url="contents/start/checks.html" />
         <mapID target="start.pentest" url="contents/pentest/pentest.html" />
-        <!--mapID target="vulns.vuln" url="contents/vulns/vulnerabilities.html" /-->
-        <!--mapID target="vulns.csrf" url="contents/vulns/csrf.html" /-->
-        <!--mapID target="vulns.idor" url="contents/vulns/idor.html" /-->
-        <!--mapID target="vulns.leak" url="contents/vulns/leak.html" /-->
-        <!--mapID target="vulns.nossl" url="contents/vulns/nossl.html" /-->
-        <!--mapID target="vulns.sqli" url="contents/vulns/sqli.html" /-->
-        <!--mapID target="vulns.urla" url="contents/vulns/urla.html" /-->
-        <!--mapID target="vulns.xss" url="contents/vulns/xss.html" /-->
         <mapID target="ui.overview" url="contents/ui/overview.html" />
         <mapID target="ui.topmenu" url="contents/ui/tlmenu/tlmenu.html" />
         <mapID target="ui.toptoolbar" url="contents/ui/tltoolbar.html" />

--- a/src/help/zaphelp_ar_SA/toc.xml
+++ b/src/help/zaphelp_ar_SA/toc.xml
@@ -47,16 +47,6 @@
       <tocitem text="A Simple Penetration Test" target="start.pentest"/>
    </tocitem>
 
-   <!--tocitem text="Common Vulnerabilities" target="vulns.vuln">
-      <tocitem text="Cross Site Request Forgery" target="vulns.csrf"/>
-      <tocitem text="Insecure Direct Object References" target="vulns.idor"/>
-      <tocitem text="Information Leakage / Improper Error Handling" target="vulns.leak"/>
-      <tocitem text="Insecure Communications" target="vulns.nossl"/>
-      <tocitem text="SQL Injection" target="vulns.sqli"/>
-      <tocitem text="Failure to restrict URL access" target="vulns.urla"/>
-      <tocitem text="Cross Site Scripts" target="vulns.xss"/>
-   </tocitem-->
-
    <tocitem text="The User Interface" target="ui.overview">
       <tocitem text="Overview" target="ui.overview"/>
       <tocitem text="The Top Level Menu" target="ui.topmenu"/>

--- a/src/help/zaphelp_az_AZ/map.jhm
+++ b/src/help/zaphelp_az_AZ/map.jhm
@@ -39,14 +39,6 @@
         <mapID target="start.concepts.users" url="contents/start/concepts/users.html" />
         <mapID target="start.checks" url="contents/start/checks.html" />
         <mapID target="start.pentest" url="contents/pentest/pentest.html" />
-        <!--mapID target="vulns.vuln" url="contents/vulns/vulnerabilities.html" /-->
-        <!--mapID target="vulns.csrf" url="contents/vulns/csrf.html" /-->
-        <!--mapID target="vulns.idor" url="contents/vulns/idor.html" /-->
-        <!--mapID target="vulns.leak" url="contents/vulns/leak.html" /-->
-        <!--mapID target="vulns.nossl" url="contents/vulns/nossl.html" /-->
-        <!--mapID target="vulns.sqli" url="contents/vulns/sqli.html" /-->
-        <!--mapID target="vulns.urla" url="contents/vulns/urla.html" /-->
-        <!--mapID target="vulns.xss" url="contents/vulns/xss.html" /-->
         <mapID target="ui.overview" url="contents/ui/overview.html" />
         <mapID target="ui.topmenu" url="contents/ui/tlmenu/tlmenu.html" />
         <mapID target="ui.toptoolbar" url="contents/ui/tltoolbar.html" />

--- a/src/help/zaphelp_az_AZ/toc.xml
+++ b/src/help/zaphelp_az_AZ/toc.xml
@@ -47,16 +47,6 @@
       <tocitem text="A Simple Penetration Test" target="start.pentest"/>
    </tocitem>
 
-   <!--tocitem text="Common Vulnerabilities" target="vulns.vuln">
-      <tocitem text="Cross Site Request Forgery" target="vulns.csrf"/>
-      <tocitem text="Insecure Direct Object References" target="vulns.idor"/>
-      <tocitem text="Information Leakage / Improper Error Handling" target="vulns.leak"/>
-      <tocitem text="Insecure Communications" target="vulns.nossl"/>
-      <tocitem text="SQL Injection" target="vulns.sqli"/>
-      <tocitem text="Failure to restrict URL access" target="vulns.urla"/>
-      <tocitem text="Cross Site Scripts" target="vulns.xss"/>
-   </tocitem-->
-
    <tocitem text="The User Interface" target="ui.overview">
       <tocitem text="Overview" target="ui.overview"/>
       <tocitem text="The Top Level Menu" target="ui.topmenu"/>

--- a/src/help/zaphelp_bs_BA/map.jhm
+++ b/src/help/zaphelp_bs_BA/map.jhm
@@ -39,14 +39,6 @@
         <mapID target="start.concepts.users" url="contents/start/concepts/users.html" />
         <mapID target="start.checks" url="contents/start/checks.html" />
         <mapID target="start.pentest" url="contents/pentest/pentest.html" />
-        <!--mapID target="vulns.vuln" url="contents/vulns/vulnerabilities.html" /-->
-        <!--mapID target="vulns.csrf" url="contents/vulns/csrf.html" /-->
-        <!--mapID target="vulns.idor" url="contents/vulns/idor.html" /-->
-        <!--mapID target="vulns.leak" url="contents/vulns/leak.html" /-->
-        <!--mapID target="vulns.nossl" url="contents/vulns/nossl.html" /-->
-        <!--mapID target="vulns.sqli" url="contents/vulns/sqli.html" /-->
-        <!--mapID target="vulns.urla" url="contents/vulns/urla.html" /-->
-        <!--mapID target="vulns.xss" url="contents/vulns/xss.html" /-->
         <mapID target="ui.overview" url="contents/ui/overview.html" />
         <mapID target="ui.topmenu" url="contents/ui/tlmenu/tlmenu.html" />
         <mapID target="ui.toptoolbar" url="contents/ui/tltoolbar.html" />

--- a/src/help/zaphelp_bs_BA/toc.xml
+++ b/src/help/zaphelp_bs_BA/toc.xml
@@ -47,16 +47,6 @@
       <tocitem text="Jednostavni Penetracijski Test" target="start.pentest"/>
    </tocitem>
 
-   <!--tocitem text="Common Vulnerabilities" target="vulns.vuln">
-      <tocitem text="Cross Site Request Forgery" target="vulns.csrf"/>
-      <tocitem text="Insecure Direct Object References" target="vulns.idor"/>
-      <tocitem text="Information Leakage / Improper Error Handling" target="vulns.leak"/>
-      <tocitem text="Insecure Communications" target="vulns.nossl"/>
-      <tocitem text="SQL Injection" target="vulns.sqli"/>
-      <tocitem text="Failure to restrict URL access" target="vulns.urla"/>
-      <tocitem text="Cross Site Scripts" target="vulns.xss"/>
-   </tocitem-->
-
    <tocitem text="Korisnički Interfejs" target="ui.overview">
       <tocitem text="Pregled" target="ui.overview"/>
       <tocitem text="Gornjeg Nivoa Meni" target="ui.topmenu"/>

--- a/src/help/zaphelp_da_DK/map.jhm
+++ b/src/help/zaphelp_da_DK/map.jhm
@@ -39,14 +39,6 @@
         <mapID target="start.concepts.users" url="contents/start/concepts/users.html" />
         <mapID target="start.checks" url="contents/start/checks.html" />
         <mapID target="start.pentest" url="contents/pentest/pentest.html" />
-        <!--mapID target="vulns.vuln" url="contents/vulns/vulnerabilities.html" /-->
-        <!--mapID target="vulns.csrf" url="contents/vulns/csrf.html" /-->
-        <!--mapID target="vulns.idor" url="contents/vulns/idor.html" /-->
-        <!--mapID target="vulns.leak" url="contents/vulns/leak.html" /-->
-        <!--mapID target="vulns.nossl" url="contents/vulns/nossl.html" /-->
-        <!--mapID target="vulns.sqli" url="contents/vulns/sqli.html" /-->
-        <!--mapID target="vulns.urla" url="contents/vulns/urla.html" /-->
-        <!--mapID target="vulns.xss" url="contents/vulns/xss.html" /-->
         <mapID target="ui.overview" url="contents/ui/overview.html" />
         <mapID target="ui.topmenu" url="contents/ui/tlmenu/tlmenu.html" />
         <mapID target="ui.toptoolbar" url="contents/ui/tltoolbar.html" />

--- a/src/help/zaphelp_da_DK/toc.xml
+++ b/src/help/zaphelp_da_DK/toc.xml
@@ -47,16 +47,6 @@
       <tocitem text="A Simple Penetration Test" target="start.pentest"/>
    </tocitem>
 
-   <!--tocitem text="Common Vulnerabilities" target="vulns.vuln">
-      <tocitem text="Cross Site Request Forgery" target="vulns.csrf"/>
-      <tocitem text="Insecure Direct Object References" target="vulns.idor"/>
-      <tocitem text="Information Leakage / Improper Error Handling" target="vulns.leak"/>
-      <tocitem text="Insecure Communications" target="vulns.nossl"/>
-      <tocitem text="SQL Injection" target="vulns.sqli"/>
-      <tocitem text="Failure to restrict URL access" target="vulns.urla"/>
-      <tocitem text="Cross Site Scripts" target="vulns.xss"/>
-   </tocitem-->
-
    <tocitem text="The User Interface" target="ui.overview">
       <tocitem text="Overview" target="ui.overview"/>
       <tocitem text="The Top Level Menu" target="ui.topmenu"/>

--- a/src/help/zaphelp_de_DE/map.jhm
+++ b/src/help/zaphelp_de_DE/map.jhm
@@ -39,14 +39,6 @@
         <mapID target="start.concepts.users" url="contents/start/concepts/users.html" />
         <mapID target="start.checks" url="contents/start/checks.html" />
         <mapID target="start.pentest" url="contents/pentest/pentest.html" />
-        <!--mapID target="vulns.vuln" url="contents/vulns/vulnerabilities.html" /-->
-        <!--mapID target="vulns.csrf" url="contents/vulns/csrf.html" /-->
-        <!--mapID target="vulns.idor" url="contents/vulns/idor.html" /-->
-        <!--mapID target="vulns.leak" url="contents/vulns/leak.html" /-->
-        <!--mapID target="vulns.nossl" url="contents/vulns/nossl.html" /-->
-        <!--mapID target="vulns.sqli" url="contents/vulns/sqli.html" /-->
-        <!--mapID target="vulns.urla" url="contents/vulns/urla.html" /-->
-        <!--mapID target="vulns.xss" url="contents/vulns/xss.html" /-->
         <mapID target="ui.overview" url="contents/ui/overview.html" />
         <mapID target="ui.topmenu" url="contents/ui/tlmenu/tlmenu.html" />
         <mapID target="ui.toptoolbar" url="contents/ui/tltoolbar.html" />

--- a/src/help/zaphelp_de_DE/toc.xml
+++ b/src/help/zaphelp_de_DE/toc.xml
@@ -47,16 +47,6 @@
       <tocitem text="A Simple Penetration Test" target="start.pentest"/>
    </tocitem>
 
-   <!--tocitem text="Common Vulnerabilities" target="vulns.vuln">
-      <tocitem text="Cross Site Request Forgery" target="vulns.csrf"/>
-      <tocitem text="Insecure Direct Object References" target="vulns.idor"/>
-      <tocitem text="Information Leakage / Improper Error Handling" target="vulns.leak"/>
-      <tocitem text="Insecure Communications" target="vulns.nossl"/>
-      <tocitem text="SQL Injection" target="vulns.sqli"/>
-      <tocitem text="Failure to restrict URL access" target="vulns.urla"/>
-      <tocitem text="Cross Site Scripts" target="vulns.xss"/>
-   </tocitem-->
-
    <tocitem text="The User Interface" target="ui.overview">
       <tocitem text="Overview" target="ui.overview"/>
       <tocitem text="The Top Level Menu" target="ui.topmenu"/>

--- a/src/help/zaphelp_el_GR/map.jhm
+++ b/src/help/zaphelp_el_GR/map.jhm
@@ -39,14 +39,6 @@
         <mapID target="start.concepts.users" url="contents/start/concepts/users.html" />
         <mapID target="start.checks" url="contents/start/checks.html" />
         <mapID target="start.pentest" url="contents/pentest/pentest.html" />
-        <!--mapID target="vulns.vuln" url="contents/vulns/vulnerabilities.html" /-->
-        <!--mapID target="vulns.csrf" url="contents/vulns/csrf.html" /-->
-        <!--mapID target="vulns.idor" url="contents/vulns/idor.html" /-->
-        <!--mapID target="vulns.leak" url="contents/vulns/leak.html" /-->
-        <!--mapID target="vulns.nossl" url="contents/vulns/nossl.html" /-->
-        <!--mapID target="vulns.sqli" url="contents/vulns/sqli.html" /-->
-        <!--mapID target="vulns.urla" url="contents/vulns/urla.html" /-->
-        <!--mapID target="vulns.xss" url="contents/vulns/xss.html" /-->
         <mapID target="ui.overview" url="contents/ui/overview.html" />
         <mapID target="ui.topmenu" url="contents/ui/tlmenu/tlmenu.html" />
         <mapID target="ui.toptoolbar" url="contents/ui/tltoolbar.html" />

--- a/src/help/zaphelp_el_GR/toc.xml
+++ b/src/help/zaphelp_el_GR/toc.xml
@@ -47,16 +47,6 @@
       <tocitem text="A Simple Penetration Test" target="start.pentest"/>
    </tocitem>
 
-   <!--tocitem text="Common Vulnerabilities" target="vulns.vuln">
-      <tocitem text="Cross Site Request Forgery" target="vulns.csrf"/>
-      <tocitem text="Insecure Direct Object References" target="vulns.idor"/>
-      <tocitem text="Information Leakage / Improper Error Handling" target="vulns.leak"/>
-      <tocitem text="Insecure Communications" target="vulns.nossl"/>
-      <tocitem text="SQL Injection" target="vulns.sqli"/>
-      <tocitem text="Failure to restrict URL access" target="vulns.urla"/>
-      <tocitem text="Cross Site Scripts" target="vulns.xss"/>
-   </tocitem-->
-
    <tocitem text="The User Interface" target="ui.overview">
       <tocitem text="Overview" target="ui.overview"/>
       <tocitem text="The Top Level Menu" target="ui.topmenu"/>

--- a/src/help/zaphelp_es_ES/map.jhm
+++ b/src/help/zaphelp_es_ES/map.jhm
@@ -39,14 +39,6 @@
         <mapID target="start.concepts.users" url="contents/start/concepts/users.html" />
         <mapID target="start.checks" url="contents/start/checks.html" />
         <mapID target="start.pentest" url="contents/pentest/pentest.html" />
-        <!--mapID target="vulns.vuln" url="contents/vulns/vulnerabilities.html" /-->
-        <!--mapID target="vulns.csrf" url="contents/vulns/csrf.html" /-->
-        <!--mapID target="vulns.idor" url="contents/vulns/idor.html" /-->
-        <!--mapID target="vulns.leak" url="contents/vulns/leak.html" /-->
-        <!--mapID target="vulns.nossl" url="contents/vulns/nossl.html" /-->
-        <!--mapID target="vulns.sqli" url="contents/vulns/sqli.html" /-->
-        <!--mapID target="vulns.urla" url="contents/vulns/urla.html" /-->
-        <!--mapID target="vulns.xss" url="contents/vulns/xss.html" /-->
         <mapID target="ui.overview" url="contents/ui/overview.html" />
         <mapID target="ui.topmenu" url="contents/ui/tlmenu/tlmenu.html" />
         <mapID target="ui.toptoolbar" url="contents/ui/tltoolbar.html" />

--- a/src/help/zaphelp_es_ES/toc.xml
+++ b/src/help/zaphelp_es_ES/toc.xml
@@ -47,16 +47,6 @@
       <tocitem text="A Simple Penetration Test" target="start.pentest"/>
    </tocitem>
 
-   <!--tocitem text="Common Vulnerabilities" target="vulns.vuln">
-      <tocitem text="Cross Site Request Forgery" target="vulns.csrf"/>
-      <tocitem text="Insecure Direct Object References" target="vulns.idor"/>
-      <tocitem text="Information Leakage / Improper Error Handling" target="vulns.leak"/>
-      <tocitem text="Insecure Communications" target="vulns.nossl"/>
-      <tocitem text="SQL Injection" target="vulns.sqli"/>
-      <tocitem text="Failure to restrict URL access" target="vulns.urla"/>
-      <tocitem text="Cross Site Scripts" target="vulns.xss"/>
-   </tocitem-->
-
    <tocitem text="The User Interface" target="ui.overview">
       <tocitem text="Overview" target="ui.overview"/>
       <tocitem text="The Top Level Menu" target="ui.topmenu"/>

--- a/src/help/zaphelp_fa_IR/map.jhm
+++ b/src/help/zaphelp_fa_IR/map.jhm
@@ -39,14 +39,6 @@
         <mapID target="start.concepts.users" url="contents/start/concepts/users.html" />
         <mapID target="start.checks" url="contents/start/checks.html" />
         <mapID target="start.pentest" url="contents/pentest/pentest.html" />
-        <!--mapID target="vulns.vuln" url="contents/vulns/vulnerabilities.html" /-->
-        <!--mapID target="vulns.csrf" url="contents/vulns/csrf.html" /-->
-        <!--mapID target="vulns.idor" url="contents/vulns/idor.html" /-->
-        <!--mapID target="vulns.leak" url="contents/vulns/leak.html" /-->
-        <!--mapID target="vulns.nossl" url="contents/vulns/nossl.html" /-->
-        <!--mapID target="vulns.sqli" url="contents/vulns/sqli.html" /-->
-        <!--mapID target="vulns.urla" url="contents/vulns/urla.html" /-->
-        <!--mapID target="vulns.xss" url="contents/vulns/xss.html" /-->
         <mapID target="ui.overview" url="contents/ui/overview.html" />
         <mapID target="ui.topmenu" url="contents/ui/tlmenu/tlmenu.html" />
         <mapID target="ui.toptoolbar" url="contents/ui/tltoolbar.html" />

--- a/src/help/zaphelp_fa_IR/toc.xml
+++ b/src/help/zaphelp_fa_IR/toc.xml
@@ -47,16 +47,6 @@
       <tocitem text="A Simple Penetration Test" target="start.pentest"/>
    </tocitem>
 
-   <!--tocitem text="Common Vulnerabilities" target="vulns.vuln">
-      <tocitem text="Cross Site Request Forgery" target="vulns.csrf"/>
-      <tocitem text="Insecure Direct Object References" target="vulns.idor"/>
-      <tocitem text="Information Leakage / Improper Error Handling" target="vulns.leak"/>
-      <tocitem text="Insecure Communications" target="vulns.nossl"/>
-      <tocitem text="SQL Injection" target="vulns.sqli"/>
-      <tocitem text="Failure to restrict URL access" target="vulns.urla"/>
-      <tocitem text="Cross Site Scripts" target="vulns.xss"/>
-   </tocitem-->
-
    <tocitem text="The User Interface" target="ui.overview">
       <tocitem text="Overview" target="ui.overview"/>
       <tocitem text="The Top Level Menu" target="ui.topmenu"/>

--- a/src/help/zaphelp_fil_PH/map.jhm
+++ b/src/help/zaphelp_fil_PH/map.jhm
@@ -39,14 +39,6 @@
         <mapID target="start.concepts.users" url="contents/start/concepts/users.html" />
         <mapID target="start.checks" url="contents/start/checks.html" />
         <mapID target="start.pentest" url="contents/pentest/pentest.html" />
-        <!--mapID target="vulns.vuln" url="contents/vulns/vulnerabilities.html" /-->
-        <!--mapID target="vulns.csrf" url="contents/vulns/csrf.html" /-->
-        <!--mapID target="vulns.idor" url="contents/vulns/idor.html" /-->
-        <!--mapID target="vulns.leak" url="contents/vulns/leak.html" /-->
-        <!--mapID target="vulns.nossl" url="contents/vulns/nossl.html" /-->
-        <!--mapID target="vulns.sqli" url="contents/vulns/sqli.html" /-->
-        <!--mapID target="vulns.urla" url="contents/vulns/urla.html" /-->
-        <!--mapID target="vulns.xss" url="contents/vulns/xss.html" /-->
         <mapID target="ui.overview" url="contents/ui/overview.html" />
         <mapID target="ui.topmenu" url="contents/ui/tlmenu/tlmenu.html" />
         <mapID target="ui.toptoolbar" url="contents/ui/tltoolbar.html" />

--- a/src/help/zaphelp_fil_PH/toc.xml
+++ b/src/help/zaphelp_fil_PH/toc.xml
@@ -47,16 +47,6 @@
       <tocitem text="Isang simpleng pagsubok sa pagbaon" target="start.pentest"/>
    </tocitem>
 
-   <!--tocitem text="Common Vulnerabilities" target="vulns.vuln">
-      <tocitem text="Cross Site Request Forgery" target="vulns.csrf"/>
-      <tocitem text="Insecure Direct Object References" target="vulns.idor"/>
-      <tocitem text="Information Leakage / Improper Error Handling" target="vulns.leak"/>
-      <tocitem text="Insecure Communications" target="vulns.nossl"/>
-      <tocitem text="SQL Injection" target="vulns.sqli"/>
-      <tocitem text="Failure to restrict URL access" target="vulns.urla"/>
-      <tocitem text="Cross Site Scripts" target="vulns.xss"/>
-   </tocitem-->
-
    <tocitem text="Ang User Interface" target="ui.overview">
       <tocitem text="Buod" target="ui.overview"/>
       <tocitem text="Ang Pinakang taas na antas na Menu" target="ui.topmenu"/>

--- a/src/help/zaphelp_fr_FR/map.jhm
+++ b/src/help/zaphelp_fr_FR/map.jhm
@@ -39,14 +39,6 @@
         <mapID target="start.concepts.users" url="contents/start/concepts/users.html" />
         <mapID target="start.checks" url="contents/start/checks.html" />
         <mapID target="start.pentest" url="contents/pentest/pentest.html" />
-        <!--mapID target="vulns.vuln" url="contents/vulns/vulnerabilities.html" /-->
-        <!--mapID target="vulns.csrf" url="contents/vulns/csrf.html" /-->
-        <!--mapID target="vulns.idor" url="contents/vulns/idor.html" /-->
-        <!--mapID target="vulns.leak" url="contents/vulns/leak.html" /-->
-        <!--mapID target="vulns.nossl" url="contents/vulns/nossl.html" /-->
-        <!--mapID target="vulns.sqli" url="contents/vulns/sqli.html" /-->
-        <!--mapID target="vulns.urla" url="contents/vulns/urla.html" /-->
-        <!--mapID target="vulns.xss" url="contents/vulns/xss.html" /-->
         <mapID target="ui.overview" url="contents/ui/overview.html" />
         <mapID target="ui.topmenu" url="contents/ui/tlmenu/tlmenu.html" />
         <mapID target="ui.toptoolbar" url="contents/ui/tltoolbar.html" />

--- a/src/help/zaphelp_fr_FR/toc.xml
+++ b/src/help/zaphelp_fr_FR/toc.xml
@@ -47,16 +47,6 @@
       <tocitem text="A Simple Penetration Test" target="start.pentest"/>
    </tocitem>
 
-   <!--tocitem text="Common Vulnerabilities" target="vulns.vuln">
-      <tocitem text="Cross Site Request Forgery" target="vulns.csrf"/>
-      <tocitem text="Insecure Direct Object References" target="vulns.idor"/>
-      <tocitem text="Information Leakage / Improper Error Handling" target="vulns.leak"/>
-      <tocitem text="Insecure Communications" target="vulns.nossl"/>
-      <tocitem text="SQL Injection" target="vulns.sqli"/>
-      <tocitem text="Failure to restrict URL access" target="vulns.urla"/>
-      <tocitem text="Cross Site Scripts" target="vulns.xss"/>
-   </tocitem-->
-
    <tocitem text="The User Interface" target="ui.overview">
       <tocitem text="Overview" target="ui.overview"/>
       <tocitem text="The Top Level Menu" target="ui.topmenu"/>

--- a/src/help/zaphelp_hi_IN/map.jhm
+++ b/src/help/zaphelp_hi_IN/map.jhm
@@ -39,14 +39,6 @@
         <mapID target="start.concepts.users" url="contents/start/concepts/users.html" />
         <mapID target="start.checks" url="contents/start/checks.html" />
         <mapID target="start.pentest" url="contents/pentest/pentest.html" />
-        <!--mapID target="vulns.vuln" url="contents/vulns/vulnerabilities.html" /-->
-        <!--mapID target="vulns.csrf" url="contents/vulns/csrf.html" /-->
-        <!--mapID target="vulns.idor" url="contents/vulns/idor.html" /-->
-        <!--mapID target="vulns.leak" url="contents/vulns/leak.html" /-->
-        <!--mapID target="vulns.nossl" url="contents/vulns/nossl.html" /-->
-        <!--mapID target="vulns.sqli" url="contents/vulns/sqli.html" /-->
-        <!--mapID target="vulns.urla" url="contents/vulns/urla.html" /-->
-        <!--mapID target="vulns.xss" url="contents/vulns/xss.html" /-->
         <mapID target="ui.overview" url="contents/ui/overview.html" />
         <mapID target="ui.topmenu" url="contents/ui/tlmenu/tlmenu.html" />
         <mapID target="ui.toptoolbar" url="contents/ui/tltoolbar.html" />

--- a/src/help/zaphelp_hi_IN/toc.xml
+++ b/src/help/zaphelp_hi_IN/toc.xml
@@ -47,16 +47,6 @@
       <tocitem text="A Simple Penetration Test" target="start.pentest"/>
    </tocitem>
 
-   <!--tocitem text="Common Vulnerabilities" target="vulns.vuln">
-      <tocitem text="Cross Site Request Forgery" target="vulns.csrf"/>
-      <tocitem text="Insecure Direct Object References" target="vulns.idor"/>
-      <tocitem text="Information Leakage / Improper Error Handling" target="vulns.leak"/>
-      <tocitem text="Insecure Communications" target="vulns.nossl"/>
-      <tocitem text="SQL Injection" target="vulns.sqli"/>
-      <tocitem text="Failure to restrict URL access" target="vulns.urla"/>
-      <tocitem text="Cross Site Scripts" target="vulns.xss"/>
-   </tocitem-->
-
    <tocitem text="The User Interface" target="ui.overview">
       <tocitem text="Overview" target="ui.overview"/>
       <tocitem text="The Top Level Menu" target="ui.topmenu"/>

--- a/src/help/zaphelp_hr_HR/map.jhm
+++ b/src/help/zaphelp_hr_HR/map.jhm
@@ -39,14 +39,6 @@
         <mapID target="start.concepts.users" url="contents/start/concepts/users.html" />
         <mapID target="start.checks" url="contents/start/checks.html" />
         <mapID target="start.pentest" url="contents/pentest/pentest.html" />
-        <!--mapID target="vulns.vuln" url="contents/vulns/vulnerabilities.html" /-->
-        <!--mapID target="vulns.csrf" url="contents/vulns/csrf.html" /-->
-        <!--mapID target="vulns.idor" url="contents/vulns/idor.html" /-->
-        <!--mapID target="vulns.leak" url="contents/vulns/leak.html" /-->
-        <!--mapID target="vulns.nossl" url="contents/vulns/nossl.html" /-->
-        <!--mapID target="vulns.sqli" url="contents/vulns/sqli.html" /-->
-        <!--mapID target="vulns.urla" url="contents/vulns/urla.html" /-->
-        <!--mapID target="vulns.xss" url="contents/vulns/xss.html" /-->
         <mapID target="ui.overview" url="contents/ui/overview.html" />
         <mapID target="ui.topmenu" url="contents/ui/tlmenu/tlmenu.html" />
         <mapID target="ui.toptoolbar" url="contents/ui/tltoolbar.html" />

--- a/src/help/zaphelp_hr_HR/toc.xml
+++ b/src/help/zaphelp_hr_HR/toc.xml
@@ -47,16 +47,6 @@
       <tocitem text="A Simple Penetration Test" target="start.pentest"/>
    </tocitem>
 
-   <!--tocitem text="Common Vulnerabilities" target="vulns.vuln">
-      <tocitem text="Cross Site Request Forgery" target="vulns.csrf"/>
-      <tocitem text="Insecure Direct Object References" target="vulns.idor"/>
-      <tocitem text="Information Leakage / Improper Error Handling" target="vulns.leak"/>
-      <tocitem text="Insecure Communications" target="vulns.nossl"/>
-      <tocitem text="SQL Injection" target="vulns.sqli"/>
-      <tocitem text="Failure to restrict URL access" target="vulns.urla"/>
-      <tocitem text="Cross Site Scripts" target="vulns.xss"/>
-   </tocitem-->
-
    <tocitem text="The User Interface" target="ui.overview">
       <tocitem text="Overview" target="ui.overview"/>
       <tocitem text="The Top Level Menu" target="ui.topmenu"/>

--- a/src/help/zaphelp_hu_HU/map.jhm
+++ b/src/help/zaphelp_hu_HU/map.jhm
@@ -39,14 +39,6 @@
         <mapID target="start.concepts.users" url="contents/start/concepts/users.html" />
         <mapID target="start.checks" url="contents/start/checks.html" />
         <mapID target="start.pentest" url="contents/pentest/pentest.html" />
-        <!--mapID target="vulns.vuln" url="contents/vulns/vulnerabilities.html" /-->
-        <!--mapID target="vulns.csrf" url="contents/vulns/csrf.html" /-->
-        <!--mapID target="vulns.idor" url="contents/vulns/idor.html" /-->
-        <!--mapID target="vulns.leak" url="contents/vulns/leak.html" /-->
-        <!--mapID target="vulns.nossl" url="contents/vulns/nossl.html" /-->
-        <!--mapID target="vulns.sqli" url="contents/vulns/sqli.html" /-->
-        <!--mapID target="vulns.urla" url="contents/vulns/urla.html" /-->
-        <!--mapID target="vulns.xss" url="contents/vulns/xss.html" /-->
         <mapID target="ui.overview" url="contents/ui/overview.html" />
         <mapID target="ui.topmenu" url="contents/ui/tlmenu/tlmenu.html" />
         <mapID target="ui.toptoolbar" url="contents/ui/tltoolbar.html" />

--- a/src/help/zaphelp_hu_HU/toc.xml
+++ b/src/help/zaphelp_hu_HU/toc.xml
@@ -47,16 +47,6 @@
       <tocitem text="A Simple Penetration Test" target="start.pentest"/>
    </tocitem>
 
-   <!--tocitem text="Common Vulnerabilities" target="vulns.vuln">
-      <tocitem text="Cross Site Request Forgery" target="vulns.csrf"/>
-      <tocitem text="Insecure Direct Object References" target="vulns.idor"/>
-      <tocitem text="Information Leakage / Improper Error Handling" target="vulns.leak"/>
-      <tocitem text="Insecure Communications" target="vulns.nossl"/>
-      <tocitem text="SQL Injection" target="vulns.sqli"/>
-      <tocitem text="Failure to restrict URL access" target="vulns.urla"/>
-      <tocitem text="Cross Site Scripts" target="vulns.xss"/>
-   </tocitem-->
-
    <tocitem text="The User Interface" target="ui.overview">
       <tocitem text="Overview" target="ui.overview"/>
       <tocitem text="The Top Level Menu" target="ui.topmenu"/>

--- a/src/help/zaphelp_id_ID/map.jhm
+++ b/src/help/zaphelp_id_ID/map.jhm
@@ -39,14 +39,6 @@
         <mapID target="start.concepts.users" url="contents/start/concepts/users.html" />
         <mapID target="start.checks" url="contents/start/checks.html" />
         <mapID target="start.pentest" url="contents/pentest/pentest.html" />
-        <!--mapID target="vulns.vuln" url="contents/vulns/vulnerabilities.html" /-->
-        <!--mapID target="vulns.csrf" url="contents/vulns/csrf.html" /-->
-        <!--mapID target="vulns.idor" url="contents/vulns/idor.html" /-->
-        <!--mapID target="vulns.leak" url="contents/vulns/leak.html" /-->
-        <!--mapID target="vulns.nossl" url="contents/vulns/nossl.html" /-->
-        <!--mapID target="vulns.sqli" url="contents/vulns/sqli.html" /-->
-        <!--mapID target="vulns.urla" url="contents/vulns/urla.html" /-->
-        <!--mapID target="vulns.xss" url="contents/vulns/xss.html" /-->
         <mapID target="ui.overview" url="contents/ui/overview.html" />
         <mapID target="ui.topmenu" url="contents/ui/tlmenu/tlmenu.html" />
         <mapID target="ui.toptoolbar" url="contents/ui/tltoolbar.html" />

--- a/src/help/zaphelp_id_ID/toc.xml
+++ b/src/help/zaphelp_id_ID/toc.xml
@@ -47,16 +47,6 @@
       <tocitem text="Sederhanakan Penetrasi Tes" target="start.pentest"/>
    </tocitem>
 
-   <!--tocitem text="Common Vulnerabilities" target="vulns.vuln">
-      <tocitem text="Cross Site Request Forgery" target="vulns.csrf"/>
-      <tocitem text="Insecure Direct Object References" target="vulns.idor"/>
-      <tocitem text="Information Leakage / Improper Error Handling" target="vulns.leak"/>
-      <tocitem text="Insecure Communications" target="vulns.nossl"/>
-      <tocitem text="SQL Injection" target="vulns.sqli"/>
-      <tocitem text="Failure to restrict URL access" target="vulns.urla"/>
-      <tocitem text="Cross Site Scripts" target="vulns.xss"/>
-   </tocitem-->
-
    <tocitem text="Antarmuka pengguna" target="ui.overview">
       <tocitem text="Ikhtisar" target="ui.overview"/>
       <tocitem text="Menu tingkat atas" target="ui.topmenu"/>

--- a/src/help/zaphelp_it_IT/map.jhm
+++ b/src/help/zaphelp_it_IT/map.jhm
@@ -39,14 +39,6 @@
         <mapID target="start.concepts.users" url="contents/start/concepts/users.html" />
         <mapID target="start.checks" url="contents/start/checks.html" />
         <mapID target="start.pentest" url="contents/pentest/pentest.html" />
-        <!--mapID target="vulns.vuln" url="contents/vulns/vulnerabilities.html" /-->
-        <!--mapID target="vulns.csrf" url="contents/vulns/csrf.html" /-->
-        <!--mapID target="vulns.idor" url="contents/vulns/idor.html" /-->
-        <!--mapID target="vulns.leak" url="contents/vulns/leak.html" /-->
-        <!--mapID target="vulns.nossl" url="contents/vulns/nossl.html" /-->
-        <!--mapID target="vulns.sqli" url="contents/vulns/sqli.html" /-->
-        <!--mapID target="vulns.urla" url="contents/vulns/urla.html" /-->
-        <!--mapID target="vulns.xss" url="contents/vulns/xss.html" /-->
         <mapID target="ui.overview" url="contents/ui/overview.html" />
         <mapID target="ui.topmenu" url="contents/ui/tlmenu/tlmenu.html" />
         <mapID target="ui.toptoolbar" url="contents/ui/tltoolbar.html" />

--- a/src/help/zaphelp_it_IT/toc.xml
+++ b/src/help/zaphelp_it_IT/toc.xml
@@ -47,16 +47,6 @@
       <tocitem text="A Simple Penetration Test" target="start.pentest"/>
    </tocitem>
 
-   <!--tocitem text="Common Vulnerabilities" target="vulns.vuln">
-      <tocitem text="Cross Site Request Forgery" target="vulns.csrf"/>
-      <tocitem text="Insecure Direct Object References" target="vulns.idor"/>
-      <tocitem text="Information Leakage / Improper Error Handling" target="vulns.leak"/>
-      <tocitem text="Insecure Communications" target="vulns.nossl"/>
-      <tocitem text="SQL Injection" target="vulns.sqli"/>
-      <tocitem text="Failure to restrict URL access" target="vulns.urla"/>
-      <tocitem text="Cross Site Scripts" target="vulns.xss"/>
-   </tocitem-->
-
    <tocitem text="The User Interface" target="ui.overview">
       <tocitem text="Overview" target="ui.overview"/>
       <tocitem text="The Top Level Menu" target="ui.topmenu"/>

--- a/src/help/zaphelp_ja_JP/map.jhm
+++ b/src/help/zaphelp_ja_JP/map.jhm
@@ -39,14 +39,6 @@
         <mapID target="start.concepts.users" url="contents/start/concepts/users.html" />
         <mapID target="start.checks" url="contents/start/checks.html" />
         <mapID target="start.pentest" url="contents/pentest/pentest.html" />
-        <!--mapID target="vulns.vuln" url="contents/vulns/vulnerabilities.html" /-->
-        <!--mapID target="vulns.csrf" url="contents/vulns/csrf.html" /-->
-        <!--mapID target="vulns.idor" url="contents/vulns/idor.html" /-->
-        <!--mapID target="vulns.leak" url="contents/vulns/leak.html" /-->
-        <!--mapID target="vulns.nossl" url="contents/vulns/nossl.html" /-->
-        <!--mapID target="vulns.sqli" url="contents/vulns/sqli.html" /-->
-        <!--mapID target="vulns.urla" url="contents/vulns/urla.html" /-->
-        <!--mapID target="vulns.xss" url="contents/vulns/xss.html" /-->
         <mapID target="ui.overview" url="contents/ui/overview.html" />
         <mapID target="ui.topmenu" url="contents/ui/tlmenu/tlmenu.html" />
         <mapID target="ui.toptoolbar" url="contents/ui/tltoolbar.html" />

--- a/src/help/zaphelp_ja_JP/toc.xml
+++ b/src/help/zaphelp_ja_JP/toc.xml
@@ -47,16 +47,6 @@
       <tocitem text="簡単なペネトレーションテスト" target="start.pentest"/>
    </tocitem>
 
-   <!--tocitem text="Common Vulnerabilities" target="vulns.vuln">
-      <tocitem text="Cross Site Request Forgery" target="vulns.csrf"/>
-      <tocitem text="Insecure Direct Object References" target="vulns.idor"/>
-      <tocitem text="Information Leakage / Improper Error Handling" target="vulns.leak"/>
-      <tocitem text="Insecure Communications" target="vulns.nossl"/>
-      <tocitem text="SQL Injection" target="vulns.sqli"/>
-      <tocitem text="Failure to restrict URL access" target="vulns.urla"/>
-      <tocitem text="Cross Site Scripts" target="vulns.xss"/>
-   </tocitem-->
-
    <tocitem text="ユーザインターフェイス" target="ui.overview">
       <tocitem text="概要" target="ui.overview"/>
       <tocitem text="トップレベルメニュー" target="ui.topmenu"/>

--- a/src/help/zaphelp_ko_KR/map.jhm
+++ b/src/help/zaphelp_ko_KR/map.jhm
@@ -39,14 +39,6 @@
         <mapID target="start.concepts.users" url="contents/start/concepts/users.html" />
         <mapID target="start.checks" url="contents/start/checks.html" />
         <mapID target="start.pentest" url="contents/pentest/pentest.html" />
-        <!--mapID target="vulns.vuln" url="contents/vulns/vulnerabilities.html" /-->
-        <!--mapID target="vulns.csrf" url="contents/vulns/csrf.html" /-->
-        <!--mapID target="vulns.idor" url="contents/vulns/idor.html" /-->
-        <!--mapID target="vulns.leak" url="contents/vulns/leak.html" /-->
-        <!--mapID target="vulns.nossl" url="contents/vulns/nossl.html" /-->
-        <!--mapID target="vulns.sqli" url="contents/vulns/sqli.html" /-->
-        <!--mapID target="vulns.urla" url="contents/vulns/urla.html" /-->
-        <!--mapID target="vulns.xss" url="contents/vulns/xss.html" /-->
         <mapID target="ui.overview" url="contents/ui/overview.html" />
         <mapID target="ui.topmenu" url="contents/ui/tlmenu/tlmenu.html" />
         <mapID target="ui.toptoolbar" url="contents/ui/tltoolbar.html" />

--- a/src/help/zaphelp_ko_KR/toc.xml
+++ b/src/help/zaphelp_ko_KR/toc.xml
@@ -47,16 +47,6 @@
       <tocitem text="A Simple Penetration Test" target="start.pentest"/>
    </tocitem>
 
-   <!--tocitem text="Common Vulnerabilities" target="vulns.vuln">
-      <tocitem text="Cross Site Request Forgery" target="vulns.csrf"/>
-      <tocitem text="Insecure Direct Object References" target="vulns.idor"/>
-      <tocitem text="Information Leakage / Improper Error Handling" target="vulns.leak"/>
-      <tocitem text="Insecure Communications" target="vulns.nossl"/>
-      <tocitem text="SQL Injection" target="vulns.sqli"/>
-      <tocitem text="Failure to restrict URL access" target="vulns.urla"/>
-      <tocitem text="Cross Site Scripts" target="vulns.xss"/>
-   </tocitem-->
-
    <tocitem text="The User Interface" target="ui.overview">
       <tocitem text="Overview" target="ui.overview"/>
       <tocitem text="The Top Level Menu" target="ui.topmenu"/>

--- a/src/help/zaphelp_ms_MY/map.jhm
+++ b/src/help/zaphelp_ms_MY/map.jhm
@@ -39,14 +39,6 @@
         <mapID target="start.concepts.users" url="contents/start/concepts/users.html" />
         <mapID target="start.checks" url="contents/start/checks.html" />
         <mapID target="start.pentest" url="contents/pentest/pentest.html" />
-        <!--mapID target="vulns.vuln" url="contents/vulns/vulnerabilities.html" /-->
-        <!--mapID target="vulns.csrf" url="contents/vulns/csrf.html" /-->
-        <!--mapID target="vulns.idor" url="contents/vulns/idor.html" /-->
-        <!--mapID target="vulns.leak" url="contents/vulns/leak.html" /-->
-        <!--mapID target="vulns.nossl" url="contents/vulns/nossl.html" /-->
-        <!--mapID target="vulns.sqli" url="contents/vulns/sqli.html" /-->
-        <!--mapID target="vulns.urla" url="contents/vulns/urla.html" /-->
-        <!--mapID target="vulns.xss" url="contents/vulns/xss.html" /-->
         <mapID target="ui.overview" url="contents/ui/overview.html" />
         <mapID target="ui.topmenu" url="contents/ui/tlmenu/tlmenu.html" />
         <mapID target="ui.toptoolbar" url="contents/ui/tltoolbar.html" />

--- a/src/help/zaphelp_ms_MY/toc.xml
+++ b/src/help/zaphelp_ms_MY/toc.xml
@@ -47,16 +47,6 @@
       <tocitem text="A Simple Penetration Test" target="start.pentest"/>
    </tocitem>
 
-   <!--tocitem text="Common Vulnerabilities" target="vulns.vuln">
-      <tocitem text="Cross Site Request Forgery" target="vulns.csrf"/>
-      <tocitem text="Insecure Direct Object References" target="vulns.idor"/>
-      <tocitem text="Information Leakage / Improper Error Handling" target="vulns.leak"/>
-      <tocitem text="Insecure Communications" target="vulns.nossl"/>
-      <tocitem text="SQL Injection" target="vulns.sqli"/>
-      <tocitem text="Failure to restrict URL access" target="vulns.urla"/>
-      <tocitem text="Cross Site Scripts" target="vulns.xss"/>
-   </tocitem-->
-
    <tocitem text="The User Interface" target="ui.overview">
       <tocitem text="Overview" target="ui.overview"/>
       <tocitem text="The Top Level Menu" target="ui.topmenu"/>

--- a/src/help/zaphelp_pl_PL/map.jhm
+++ b/src/help/zaphelp_pl_PL/map.jhm
@@ -39,14 +39,6 @@
         <mapID target="start.concepts.users" url="contents/start/concepts/users.html" />
         <mapID target="start.checks" url="contents/start/checks.html" />
         <mapID target="start.pentest" url="contents/pentest/pentest.html" />
-        <!--mapID target="vulns.vuln" url="contents/vulns/vulnerabilities.html" /-->
-        <!--mapID target="vulns.csrf" url="contents/vulns/csrf.html" /-->
-        <!--mapID target="vulns.idor" url="contents/vulns/idor.html" /-->
-        <!--mapID target="vulns.leak" url="contents/vulns/leak.html" /-->
-        <!--mapID target="vulns.nossl" url="contents/vulns/nossl.html" /-->
-        <!--mapID target="vulns.sqli" url="contents/vulns/sqli.html" /-->
-        <!--mapID target="vulns.urla" url="contents/vulns/urla.html" /-->
-        <!--mapID target="vulns.xss" url="contents/vulns/xss.html" /-->
         <mapID target="ui.overview" url="contents/ui/overview.html" />
         <mapID target="ui.topmenu" url="contents/ui/tlmenu/tlmenu.html" />
         <mapID target="ui.toptoolbar" url="contents/ui/tltoolbar.html" />

--- a/src/help/zaphelp_pl_PL/toc.xml
+++ b/src/help/zaphelp_pl_PL/toc.xml
@@ -47,16 +47,6 @@
       <tocitem text="A Simple Penetration Test" target="start.pentest"/>
    </tocitem>
 
-   <!--tocitem text="Common Vulnerabilities" target="vulns.vuln">
-      <tocitem text="Cross Site Request Forgery" target="vulns.csrf"/>
-      <tocitem text="Insecure Direct Object References" target="vulns.idor"/>
-      <tocitem text="Information Leakage / Improper Error Handling" target="vulns.leak"/>
-      <tocitem text="Insecure Communications" target="vulns.nossl"/>
-      <tocitem text="SQL Injection" target="vulns.sqli"/>
-      <tocitem text="Failure to restrict URL access" target="vulns.urla"/>
-      <tocitem text="Cross Site Scripts" target="vulns.xss"/>
-   </tocitem-->
-
    <tocitem text="The User Interface" target="ui.overview">
       <tocitem text="Overview" target="ui.overview"/>
       <tocitem text="The Top Level Menu" target="ui.topmenu"/>

--- a/src/help/zaphelp_pt_BR/map.jhm
+++ b/src/help/zaphelp_pt_BR/map.jhm
@@ -39,14 +39,6 @@
         <mapID target="start.concepts.users" url="contents/start/concepts/users.html" />
         <mapID target="start.checks" url="contents/start/checks.html" />
         <mapID target="start.pentest" url="contents/pentest/pentest.html" />
-        <!--mapID target="vulns.vuln" url="contents/vulns/vulnerabilities.html" /-->
-        <!--mapID target="vulns.csrf" url="contents/vulns/csrf.html" /-->
-        <!--mapID target="vulns.idor" url="contents/vulns/idor.html" /-->
-        <!--mapID target="vulns.leak" url="contents/vulns/leak.html" /-->
-        <!--mapID target="vulns.nossl" url="contents/vulns/nossl.html" /-->
-        <!--mapID target="vulns.sqli" url="contents/vulns/sqli.html" /-->
-        <!--mapID target="vulns.urla" url="contents/vulns/urla.html" /-->
-        <!--mapID target="vulns.xss" url="contents/vulns/xss.html" /-->
         <mapID target="ui.overview" url="contents/ui/overview.html" />
         <mapID target="ui.topmenu" url="contents/ui/tlmenu/tlmenu.html" />
         <mapID target="ui.toptoolbar" url="contents/ui/tltoolbar.html" />

--- a/src/help/zaphelp_pt_BR/toc.xml
+++ b/src/help/zaphelp_pt_BR/toc.xml
@@ -47,16 +47,6 @@
       <tocitem text="Um teste de penetração simples" target="start.pentest"/>
    </tocitem>
 
-   <!--tocitem text="Common Vulnerabilities" target="vulns.vuln">
-      <tocitem text="Cross Site Request Forgery" target="vulns.csrf"/>
-      <tocitem text="Insecure Direct Object References" target="vulns.idor"/>
-      <tocitem text="Information Leakage / Improper Error Handling" target="vulns.leak"/>
-      <tocitem text="Insecure Communications" target="vulns.nossl"/>
-      <tocitem text="SQL Injection" target="vulns.sqli"/>
-      <tocitem text="Failure to restrict URL access" target="vulns.urla"/>
-      <tocitem text="Cross Site Scripts" target="vulns.xss"/>
-   </tocitem-->
-
    <tocitem text="A interface do usuário" target="ui.overview">
       <tocitem text="Visão Geral" target="ui.overview"/>
       <tocitem text="Menu superior" target="ui.topmenu"/>

--- a/src/help/zaphelp_ro_RO/map.jhm
+++ b/src/help/zaphelp_ro_RO/map.jhm
@@ -39,14 +39,6 @@
         <mapID target="start.concepts.users" url="contents/start/concepts/users.html" />
         <mapID target="start.checks" url="contents/start/checks.html" />
         <mapID target="start.pentest" url="contents/pentest/pentest.html" />
-        <!--mapID target="vulns.vuln" url="contents/vulns/vulnerabilities.html" /-->
-        <!--mapID target="vulns.csrf" url="contents/vulns/csrf.html" /-->
-        <!--mapID target="vulns.idor" url="contents/vulns/idor.html" /-->
-        <!--mapID target="vulns.leak" url="contents/vulns/leak.html" /-->
-        <!--mapID target="vulns.nossl" url="contents/vulns/nossl.html" /-->
-        <!--mapID target="vulns.sqli" url="contents/vulns/sqli.html" /-->
-        <!--mapID target="vulns.urla" url="contents/vulns/urla.html" /-->
-        <!--mapID target="vulns.xss" url="contents/vulns/xss.html" /-->
         <mapID target="ui.overview" url="contents/ui/overview.html" />
         <mapID target="ui.topmenu" url="contents/ui/tlmenu/tlmenu.html" />
         <mapID target="ui.toptoolbar" url="contents/ui/tltoolbar.html" />

--- a/src/help/zaphelp_ro_RO/toc.xml
+++ b/src/help/zaphelp_ro_RO/toc.xml
@@ -47,16 +47,6 @@
       <tocitem text="A Simple Penetration Test" target="start.pentest"/>
    </tocitem>
 
-   <!--tocitem text="Common Vulnerabilities" target="vulns.vuln">
-      <tocitem text="Cross Site Request Forgery" target="vulns.csrf"/>
-      <tocitem text="Insecure Direct Object References" target="vulns.idor"/>
-      <tocitem text="Information Leakage / Improper Error Handling" target="vulns.leak"/>
-      <tocitem text="Insecure Communications" target="vulns.nossl"/>
-      <tocitem text="SQL Injection" target="vulns.sqli"/>
-      <tocitem text="Failure to restrict URL access" target="vulns.urla"/>
-      <tocitem text="Cross Site Scripts" target="vulns.xss"/>
-   </tocitem-->
-
    <tocitem text="The User Interface" target="ui.overview">
       <tocitem text="Overview" target="ui.overview"/>
       <tocitem text="The Top Level Menu" target="ui.topmenu"/>

--- a/src/help/zaphelp_ru_RU/map.jhm
+++ b/src/help/zaphelp_ru_RU/map.jhm
@@ -39,14 +39,6 @@
         <mapID target="start.concepts.users" url="contents/start/concepts/users.html" />
         <mapID target="start.checks" url="contents/start/checks.html" />
         <mapID target="start.pentest" url="contents/pentest/pentest.html" />
-        <!--mapID target="vulns.vuln" url="contents/vulns/vulnerabilities.html" /-->
-        <!--mapID target="vulns.csrf" url="contents/vulns/csrf.html" /-->
-        <!--mapID target="vulns.idor" url="contents/vulns/idor.html" /-->
-        <!--mapID target="vulns.leak" url="contents/vulns/leak.html" /-->
-        <!--mapID target="vulns.nossl" url="contents/vulns/nossl.html" /-->
-        <!--mapID target="vulns.sqli" url="contents/vulns/sqli.html" /-->
-        <!--mapID target="vulns.urla" url="contents/vulns/urla.html" /-->
-        <!--mapID target="vulns.xss" url="contents/vulns/xss.html" /-->
         <mapID target="ui.overview" url="contents/ui/overview.html" />
         <mapID target="ui.topmenu" url="contents/ui/tlmenu/tlmenu.html" />
         <mapID target="ui.toptoolbar" url="contents/ui/tltoolbar.html" />

--- a/src/help/zaphelp_ru_RU/toc.xml
+++ b/src/help/zaphelp_ru_RU/toc.xml
@@ -47,16 +47,6 @@
       <tocitem text="A Simple Penetration Test" target="start.pentest"/>
    </tocitem>
 
-   <!--tocitem text="Common Vulnerabilities" target="vulns.vuln">
-      <tocitem text="Cross Site Request Forgery" target="vulns.csrf"/>
-      <tocitem text="Insecure Direct Object References" target="vulns.idor"/>
-      <tocitem text="Information Leakage / Improper Error Handling" target="vulns.leak"/>
-      <tocitem text="Insecure Communications" target="vulns.nossl"/>
-      <tocitem text="SQL Injection" target="vulns.sqli"/>
-      <tocitem text="Failure to restrict URL access" target="vulns.urla"/>
-      <tocitem text="Cross Site Scripts" target="vulns.xss"/>
-   </tocitem-->
-
    <tocitem text="The User Interface" target="ui.overview">
       <tocitem text="Overview" target="ui.overview"/>
       <tocitem text="The Top Level Menu" target="ui.topmenu"/>

--- a/src/help/zaphelp_si_LK/map.jhm
+++ b/src/help/zaphelp_si_LK/map.jhm
@@ -39,14 +39,6 @@
         <mapID target="start.concepts.users" url="contents/start/concepts/users.html" />
         <mapID target="start.checks" url="contents/start/checks.html" />
         <mapID target="start.pentest" url="contents/pentest/pentest.html" />
-        <!--mapID target="vulns.vuln" url="contents/vulns/vulnerabilities.html" /-->
-        <!--mapID target="vulns.csrf" url="contents/vulns/csrf.html" /-->
-        <!--mapID target="vulns.idor" url="contents/vulns/idor.html" /-->
-        <!--mapID target="vulns.leak" url="contents/vulns/leak.html" /-->
-        <!--mapID target="vulns.nossl" url="contents/vulns/nossl.html" /-->
-        <!--mapID target="vulns.sqli" url="contents/vulns/sqli.html" /-->
-        <!--mapID target="vulns.urla" url="contents/vulns/urla.html" /-->
-        <!--mapID target="vulns.xss" url="contents/vulns/xss.html" /-->
         <mapID target="ui.overview" url="contents/ui/overview.html" />
         <mapID target="ui.topmenu" url="contents/ui/tlmenu/tlmenu.html" />
         <mapID target="ui.toptoolbar" url="contents/ui/tltoolbar.html" />

--- a/src/help/zaphelp_si_LK/toc.xml
+++ b/src/help/zaphelp_si_LK/toc.xml
@@ -47,16 +47,6 @@
       <tocitem text="A Simple Penetration Test" target="start.pentest"/>
    </tocitem>
 
-   <!--tocitem text="Common Vulnerabilities" target="vulns.vuln">
-      <tocitem text="Cross Site Request Forgery" target="vulns.csrf"/>
-      <tocitem text="Insecure Direct Object References" target="vulns.idor"/>
-      <tocitem text="Information Leakage / Improper Error Handling" target="vulns.leak"/>
-      <tocitem text="Insecure Communications" target="vulns.nossl"/>
-      <tocitem text="SQL Injection" target="vulns.sqli"/>
-      <tocitem text="Failure to restrict URL access" target="vulns.urla"/>
-      <tocitem text="Cross Site Scripts" target="vulns.xss"/>
-   </tocitem-->
-
    <tocitem text="The User Interface" target="ui.overview">
       <tocitem text="Overview" target="ui.overview"/>
       <tocitem text="The Top Level Menu" target="ui.topmenu"/>

--- a/src/help/zaphelp_sk_SK/map.jhm
+++ b/src/help/zaphelp_sk_SK/map.jhm
@@ -39,14 +39,6 @@
         <mapID target="start.concepts.users" url="contents/start/concepts/users.html" />
         <mapID target="start.checks" url="contents/start/checks.html" />
         <mapID target="start.pentest" url="contents/pentest/pentest.html" />
-        <!--mapID target="vulns.vuln" url="contents/vulns/vulnerabilities.html" /-->
-        <!--mapID target="vulns.csrf" url="contents/vulns/csrf.html" /-->
-        <!--mapID target="vulns.idor" url="contents/vulns/idor.html" /-->
-        <!--mapID target="vulns.leak" url="contents/vulns/leak.html" /-->
-        <!--mapID target="vulns.nossl" url="contents/vulns/nossl.html" /-->
-        <!--mapID target="vulns.sqli" url="contents/vulns/sqli.html" /-->
-        <!--mapID target="vulns.urla" url="contents/vulns/urla.html" /-->
-        <!--mapID target="vulns.xss" url="contents/vulns/xss.html" /-->
         <mapID target="ui.overview" url="contents/ui/overview.html" />
         <mapID target="ui.topmenu" url="contents/ui/tlmenu/tlmenu.html" />
         <mapID target="ui.toptoolbar" url="contents/ui/tltoolbar.html" />

--- a/src/help/zaphelp_sk_SK/toc.xml
+++ b/src/help/zaphelp_sk_SK/toc.xml
@@ -47,16 +47,6 @@
       <tocitem text="A Simple Penetration Test" target="start.pentest"/>
    </tocitem>
 
-   <!--tocitem text="Common Vulnerabilities" target="vulns.vuln">
-      <tocitem text="Cross Site Request Forgery" target="vulns.csrf"/>
-      <tocitem text="Insecure Direct Object References" target="vulns.idor"/>
-      <tocitem text="Information Leakage / Improper Error Handling" target="vulns.leak"/>
-      <tocitem text="Insecure Communications" target="vulns.nossl"/>
-      <tocitem text="SQL Injection" target="vulns.sqli"/>
-      <tocitem text="Failure to restrict URL access" target="vulns.urla"/>
-      <tocitem text="Cross Site Scripts" target="vulns.xss"/>
-   </tocitem-->
-
    <tocitem text="The User Interface" target="ui.overview">
       <tocitem text="Overview" target="ui.overview"/>
       <tocitem text="The Top Level Menu" target="ui.topmenu"/>

--- a/src/help/zaphelp_sl_SI/map.jhm
+++ b/src/help/zaphelp_sl_SI/map.jhm
@@ -39,14 +39,6 @@
         <mapID target="start.concepts.users" url="contents/start/concepts/users.html" />
         <mapID target="start.checks" url="contents/start/checks.html" />
         <mapID target="start.pentest" url="contents/pentest/pentest.html" />
-        <!--mapID target="vulns.vuln" url="contents/vulns/vulnerabilities.html" /-->
-        <!--mapID target="vulns.csrf" url="contents/vulns/csrf.html" /-->
-        <!--mapID target="vulns.idor" url="contents/vulns/idor.html" /-->
-        <!--mapID target="vulns.leak" url="contents/vulns/leak.html" /-->
-        <!--mapID target="vulns.nossl" url="contents/vulns/nossl.html" /-->
-        <!--mapID target="vulns.sqli" url="contents/vulns/sqli.html" /-->
-        <!--mapID target="vulns.urla" url="contents/vulns/urla.html" /-->
-        <!--mapID target="vulns.xss" url="contents/vulns/xss.html" /-->
         <mapID target="ui.overview" url="contents/ui/overview.html" />
         <mapID target="ui.topmenu" url="contents/ui/tlmenu/tlmenu.html" />
         <mapID target="ui.toptoolbar" url="contents/ui/tltoolbar.html" />

--- a/src/help/zaphelp_sl_SI/toc.xml
+++ b/src/help/zaphelp_sl_SI/toc.xml
@@ -47,16 +47,6 @@
       <tocitem text="A Simple Penetration Test" target="start.pentest"/>
    </tocitem>
 
-   <!--tocitem text="Common Vulnerabilities" target="vulns.vuln">
-      <tocitem text="Cross Site Request Forgery" target="vulns.csrf"/>
-      <tocitem text="Insecure Direct Object References" target="vulns.idor"/>
-      <tocitem text="Information Leakage / Improper Error Handling" target="vulns.leak"/>
-      <tocitem text="Insecure Communications" target="vulns.nossl"/>
-      <tocitem text="SQL Injection" target="vulns.sqli"/>
-      <tocitem text="Failure to restrict URL access" target="vulns.urla"/>
-      <tocitem text="Cross Site Scripts" target="vulns.xss"/>
-   </tocitem-->
-
    <tocitem text="The User Interface" target="ui.overview">
       <tocitem text="Overview" target="ui.overview"/>
       <tocitem text="The Top Level Menu" target="ui.topmenu"/>

--- a/src/help/zaphelp_sq_AL/map.jhm
+++ b/src/help/zaphelp_sq_AL/map.jhm
@@ -39,14 +39,6 @@
         <mapID target="start.concepts.users" url="contents/start/concepts/users.html" />
         <mapID target="start.checks" url="contents/start/checks.html" />
         <mapID target="start.pentest" url="contents/pentest/pentest.html" />
-        <!--mapID target="vulns.vuln" url="contents/vulns/vulnerabilities.html" /-->
-        <!--mapID target="vulns.csrf" url="contents/vulns/csrf.html" /-->
-        <!--mapID target="vulns.idor" url="contents/vulns/idor.html" /-->
-        <!--mapID target="vulns.leak" url="contents/vulns/leak.html" /-->
-        <!--mapID target="vulns.nossl" url="contents/vulns/nossl.html" /-->
-        <!--mapID target="vulns.sqli" url="contents/vulns/sqli.html" /-->
-        <!--mapID target="vulns.urla" url="contents/vulns/urla.html" /-->
-        <!--mapID target="vulns.xss" url="contents/vulns/xss.html" /-->
         <mapID target="ui.overview" url="contents/ui/overview.html" />
         <mapID target="ui.topmenu" url="contents/ui/tlmenu/tlmenu.html" />
         <mapID target="ui.toptoolbar" url="contents/ui/tltoolbar.html" />

--- a/src/help/zaphelp_sq_AL/toc.xml
+++ b/src/help/zaphelp_sq_AL/toc.xml
@@ -47,16 +47,6 @@
       <tocitem text="A Simple Penetration Test" target="start.pentest"/>
    </tocitem>
 
-   <!--tocitem text="Common Vulnerabilities" target="vulns.vuln">
-      <tocitem text="Cross Site Request Forgery" target="vulns.csrf"/>
-      <tocitem text="Insecure Direct Object References" target="vulns.idor"/>
-      <tocitem text="Information Leakage / Improper Error Handling" target="vulns.leak"/>
-      <tocitem text="Insecure Communications" target="vulns.nossl"/>
-      <tocitem text="SQL Injection" target="vulns.sqli"/>
-      <tocitem text="Failure to restrict URL access" target="vulns.urla"/>
-      <tocitem text="Cross Site Scripts" target="vulns.xss"/>
-   </tocitem-->
-
    <tocitem text="The User Interface" target="ui.overview">
       <tocitem text="Overview" target="ui.overview"/>
       <tocitem text="The Top Level Menu" target="ui.topmenu"/>

--- a/src/help/zaphelp_sr_CS/map.jhm
+++ b/src/help/zaphelp_sr_CS/map.jhm
@@ -39,14 +39,6 @@
         <mapID target="start.concepts.users" url="contents/start/concepts/users.html" />
         <mapID target="start.checks" url="contents/start/checks.html" />
         <mapID target="start.pentest" url="contents/pentest/pentest.html" />
-        <!--mapID target="vulns.vuln" url="contents/vulns/vulnerabilities.html" /-->
-        <!--mapID target="vulns.csrf" url="contents/vulns/csrf.html" /-->
-        <!--mapID target="vulns.idor" url="contents/vulns/idor.html" /-->
-        <!--mapID target="vulns.leak" url="contents/vulns/leak.html" /-->
-        <!--mapID target="vulns.nossl" url="contents/vulns/nossl.html" /-->
-        <!--mapID target="vulns.sqli" url="contents/vulns/sqli.html" /-->
-        <!--mapID target="vulns.urla" url="contents/vulns/urla.html" /-->
-        <!--mapID target="vulns.xss" url="contents/vulns/xss.html" /-->
         <mapID target="ui.overview" url="contents/ui/overview.html" />
         <mapID target="ui.topmenu" url="contents/ui/tlmenu/tlmenu.html" />
         <mapID target="ui.toptoolbar" url="contents/ui/tltoolbar.html" />

--- a/src/help/zaphelp_sr_CS/toc.xml
+++ b/src/help/zaphelp_sr_CS/toc.xml
@@ -47,16 +47,6 @@
       <tocitem text="A Simple Penetration Test" target="start.pentest"/>
    </tocitem>
 
-   <!--tocitem text="Common Vulnerabilities" target="vulns.vuln">
-      <tocitem text="Cross Site Request Forgery" target="vulns.csrf"/>
-      <tocitem text="Insecure Direct Object References" target="vulns.idor"/>
-      <tocitem text="Information Leakage / Improper Error Handling" target="vulns.leak"/>
-      <tocitem text="Insecure Communications" target="vulns.nossl"/>
-      <tocitem text="SQL Injection" target="vulns.sqli"/>
-      <tocitem text="Failure to restrict URL access" target="vulns.urla"/>
-      <tocitem text="Cross Site Scripts" target="vulns.xss"/>
-   </tocitem-->
-
    <tocitem text="The User Interface" target="ui.overview">
       <tocitem text="Overview" target="ui.overview"/>
       <tocitem text="The Top Level Menu" target="ui.topmenu"/>

--- a/src/help/zaphelp_sr_SP/map.jhm
+++ b/src/help/zaphelp_sr_SP/map.jhm
@@ -39,14 +39,6 @@
         <mapID target="start.concepts.users" url="contents/start/concepts/users.html" />
         <mapID target="start.checks" url="contents/start/checks.html" />
         <mapID target="start.pentest" url="contents/pentest/pentest.html" />
-        <!--mapID target="vulns.vuln" url="contents/vulns/vulnerabilities.html" /-->
-        <!--mapID target="vulns.csrf" url="contents/vulns/csrf.html" /-->
-        <!--mapID target="vulns.idor" url="contents/vulns/idor.html" /-->
-        <!--mapID target="vulns.leak" url="contents/vulns/leak.html" /-->
-        <!--mapID target="vulns.nossl" url="contents/vulns/nossl.html" /-->
-        <!--mapID target="vulns.sqli" url="contents/vulns/sqli.html" /-->
-        <!--mapID target="vulns.urla" url="contents/vulns/urla.html" /-->
-        <!--mapID target="vulns.xss" url="contents/vulns/xss.html" /-->
         <mapID target="ui.overview" url="contents/ui/overview.html" />
         <mapID target="ui.topmenu" url="contents/ui/tlmenu/tlmenu.html" />
         <mapID target="ui.toptoolbar" url="contents/ui/tltoolbar.html" />

--- a/src/help/zaphelp_sr_SP/toc.xml
+++ b/src/help/zaphelp_sr_SP/toc.xml
@@ -47,16 +47,6 @@
       <tocitem text="A Simple Penetration Test" target="start.pentest"/>
    </tocitem>
 
-   <!--tocitem text="Common Vulnerabilities" target="vulns.vuln">
-      <tocitem text="Cross Site Request Forgery" target="vulns.csrf"/>
-      <tocitem text="Insecure Direct Object References" target="vulns.idor"/>
-      <tocitem text="Information Leakage / Improper Error Handling" target="vulns.leak"/>
-      <tocitem text="Insecure Communications" target="vulns.nossl"/>
-      <tocitem text="SQL Injection" target="vulns.sqli"/>
-      <tocitem text="Failure to restrict URL access" target="vulns.urla"/>
-      <tocitem text="Cross Site Scripts" target="vulns.xss"/>
-   </tocitem-->
-
    <tocitem text="The User Interface" target="ui.overview">
       <tocitem text="Overview" target="ui.overview"/>
       <tocitem text="The Top Level Menu" target="ui.topmenu"/>

--- a/src/help/zaphelp_tr_TR/map.jhm
+++ b/src/help/zaphelp_tr_TR/map.jhm
@@ -39,14 +39,6 @@
         <mapID target="start.concepts.users" url="contents/start/concepts/users.html" />
         <mapID target="start.checks" url="contents/start/checks.html" />
         <mapID target="start.pentest" url="contents/pentest/pentest.html" />
-        <!--mapID target="vulns.vuln" url="contents/vulns/vulnerabilities.html" /-->
-        <!--mapID target="vulns.csrf" url="contents/vulns/csrf.html" /-->
-        <!--mapID target="vulns.idor" url="contents/vulns/idor.html" /-->
-        <!--mapID target="vulns.leak" url="contents/vulns/leak.html" /-->
-        <!--mapID target="vulns.nossl" url="contents/vulns/nossl.html" /-->
-        <!--mapID target="vulns.sqli" url="contents/vulns/sqli.html" /-->
-        <!--mapID target="vulns.urla" url="contents/vulns/urla.html" /-->
-        <!--mapID target="vulns.xss" url="contents/vulns/xss.html" /-->
         <mapID target="ui.overview" url="contents/ui/overview.html" />
         <mapID target="ui.topmenu" url="contents/ui/tlmenu/tlmenu.html" />
         <mapID target="ui.toptoolbar" url="contents/ui/tltoolbar.html" />

--- a/src/help/zaphelp_tr_TR/toc.xml
+++ b/src/help/zaphelp_tr_TR/toc.xml
@@ -47,16 +47,6 @@
       <tocitem text="Basit Penetration testi" target="start.pentest"/>
    </tocitem>
 
-   <!--tocitem text="Common Vulnerabilities" target="vulns.vuln">
-      <tocitem text="Cross Site Request Forgery" target="vulns.csrf"/>
-      <tocitem text="Insecure Direct Object References" target="vulns.idor"/>
-      <tocitem text="Information Leakage / Improper Error Handling" target="vulns.leak"/>
-      <tocitem text="Insecure Communications" target="vulns.nossl"/>
-      <tocitem text="SQL Injection" target="vulns.sqli"/>
-      <tocitem text="Failure to restrict URL access" target="vulns.urla"/>
-      <tocitem text="Cross Site Scripts" target="vulns.xss"/>
-   </tocitem-->
-
    <tocitem text="Kullanıcı Arayüzü" target="ui.overview">
       <tocitem text="Genel Bakış" target="ui.overview"/>
       <tocitem text="Üst Düzey Menü" target="ui.topmenu"/>

--- a/src/help/zaphelp_ur_PK/map.jhm
+++ b/src/help/zaphelp_ur_PK/map.jhm
@@ -39,14 +39,6 @@
         <mapID target="start.concepts.users" url="contents/start/concepts/users.html" />
         <mapID target="start.checks" url="contents/start/checks.html" />
         <mapID target="start.pentest" url="contents/pentest/pentest.html" />
-        <!--mapID target="vulns.vuln" url="contents/vulns/vulnerabilities.html" /-->
-        <!--mapID target="vulns.csrf" url="contents/vulns/csrf.html" /-->
-        <!--mapID target="vulns.idor" url="contents/vulns/idor.html" /-->
-        <!--mapID target="vulns.leak" url="contents/vulns/leak.html" /-->
-        <!--mapID target="vulns.nossl" url="contents/vulns/nossl.html" /-->
-        <!--mapID target="vulns.sqli" url="contents/vulns/sqli.html" /-->
-        <!--mapID target="vulns.urla" url="contents/vulns/urla.html" /-->
-        <!--mapID target="vulns.xss" url="contents/vulns/xss.html" /-->
         <mapID target="ui.overview" url="contents/ui/overview.html" />
         <mapID target="ui.topmenu" url="contents/ui/tlmenu/tlmenu.html" />
         <mapID target="ui.toptoolbar" url="contents/ui/tltoolbar.html" />

--- a/src/help/zaphelp_ur_PK/toc.xml
+++ b/src/help/zaphelp_ur_PK/toc.xml
@@ -47,16 +47,6 @@
       <tocitem text="A Simple Penetration Test" target="start.pentest"/>
    </tocitem>
 
-   <!--tocitem text="Common Vulnerabilities" target="vulns.vuln">
-      <tocitem text="Cross Site Request Forgery" target="vulns.csrf"/>
-      <tocitem text="Insecure Direct Object References" target="vulns.idor"/>
-      <tocitem text="Information Leakage / Improper Error Handling" target="vulns.leak"/>
-      <tocitem text="Insecure Communications" target="vulns.nossl"/>
-      <tocitem text="SQL Injection" target="vulns.sqli"/>
-      <tocitem text="Failure to restrict URL access" target="vulns.urla"/>
-      <tocitem text="Cross Site Scripts" target="vulns.xss"/>
-   </tocitem-->
-
    <tocitem text="The User Interface" target="ui.overview">
       <tocitem text="Overview" target="ui.overview"/>
       <tocitem text="The Top Level Menu" target="ui.topmenu"/>

--- a/src/help/zaphelp_zh_CN/map.jhm
+++ b/src/help/zaphelp_zh_CN/map.jhm
@@ -39,14 +39,6 @@
         <mapID target="start.concepts.users" url="contents/start/concepts/users.html" />
         <mapID target="start.checks" url="contents/start/checks.html" />
         <mapID target="start.pentest" url="contents/pentest/pentest.html" />
-        <!--mapID target="vulns.vuln" url="contents/vulns/vulnerabilities.html" /-->
-        <!--mapID target="vulns.csrf" url="contents/vulns/csrf.html" /-->
-        <!--mapID target="vulns.idor" url="contents/vulns/idor.html" /-->
-        <!--mapID target="vulns.leak" url="contents/vulns/leak.html" /-->
-        <!--mapID target="vulns.nossl" url="contents/vulns/nossl.html" /-->
-        <!--mapID target="vulns.sqli" url="contents/vulns/sqli.html" /-->
-        <!--mapID target="vulns.urla" url="contents/vulns/urla.html" /-->
-        <!--mapID target="vulns.xss" url="contents/vulns/xss.html" /-->
         <mapID target="ui.overview" url="contents/ui/overview.html" />
         <mapID target="ui.topmenu" url="contents/ui/tlmenu/tlmenu.html" />
         <mapID target="ui.toptoolbar" url="contents/ui/tltoolbar.html" />

--- a/src/help/zaphelp_zh_CN/toc.xml
+++ b/src/help/zaphelp_zh_CN/toc.xml
@@ -47,16 +47,6 @@
       <tocitem text="简单的渗透测试" target="start.pentest"/>
    </tocitem>
 
-   <!--tocitem text="Common Vulnerabilities" target="vulns.vuln">
-      <tocitem text="Cross Site Request Forgery" target="vulns.csrf"/>
-      <tocitem text="Insecure Direct Object References" target="vulns.idor"/>
-      <tocitem text="Information Leakage / Improper Error Handling" target="vulns.leak"/>
-      <tocitem text="Insecure Communications" target="vulns.nossl"/>
-      <tocitem text="SQL Injection" target="vulns.sqli"/>
-      <tocitem text="Failure to restrict URL access" target="vulns.urla"/>
-      <tocitem text="Cross Site Scripts" target="vulns.xss"/>
-   </tocitem-->
-
    <tocitem text="用户界面" target="ui.overview">
       <tocitem text="综述" target="ui.overview"/>
       <tocitem text="顶级菜单" target="ui.topmenu"/>


### PR DESCRIPTION
Remove commented TOC/map entries (in all languages), those are not
likely to be used any more, the add-ons with scanners have their own
help with the description about the alerts raised.