### PR TITLE
Remove button from Spider tab help page

### DIFF
--- a/src/help/zaphelp/contents/ui/tabs/spider.html
+++ b/src/help/zaphelp/contents/ui/tabs/spider.html
@@ -30,9 +30,6 @@ to specify exactly what should be scanned.<br>
 			the selected spider scan;</li>
 		<li><img align="bottom" alt="clean scans button" src="../../images/fugue/broom.png">
 			Clean completed scans;</li>
-		<li><img align="bottom" alt="show messages button" src="../../images/16/178.png">
-			Show/Hide Messages - shows/hides a tab (called Messages) that displays all HTTP
-			messages sent by the selected spider scan;</li>
 		<li><img align="bottom" alt="spider options button" src="../../images/16/041.png">
 			Open the <a href="../../ui/dialogs/options/spider.html">Spider Options screen</a>.</li>
 	</ul>


### PR DESCRIPTION
Remove button that no longer exists in the latest versions (>=2.7.0),
the Messages tab is now always visible.