### PR TITLE
Fix broken links and address redirections

### DIFF
--- a/src/help/zaphelp/contents/credits.html
+++ b/src/help/zaphelp/contents/credits.html
@@ -82,7 +82,7 @@ People who have made contributions to ZAP over the years, in alphabetical order:
 <tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td>April King</td></tr>
 <tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td>Martin W. Kirst (MaWoKi)</td></tr>
 <tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td>Manos Kirtas</td></tr>
-<tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td>Juha Kivekäs (<a href="https://twitter.com/juhakivekas">@juhakivekas</a>)</td></tr>
+<tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td>Juha Kivekäs (<a href="https://twitter.com/_guttula">@_guttula</a>)</td></tr>
 <tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td>Dennis Kniep</td></tr>
 <tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td>Robert Koch</td></tr>
 <tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td>Lars Kristensen</td></tr>
@@ -194,15 +194,15 @@ JavaHelp</td><td> <a href="http://java.sun.com/javase/technologies/desktop/javah
 <tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td>
 OWASP DirBuster</td><td> <a href="https://www.owasp.org/index.php/Category:OWASP_DirBuster_Project">https://www.owasp.org/index.php/Category:OWASP_DirBuster_Project</a></td></tr>
 <tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td>
-OWASP JBroFuzz</td><td> <a href="https://www.owasp.org/index.php/JBroFuzz/">https://www.owasp.org/index.php/JBroFuzz/</a></td></tr>
+OWASP JBroFuzz</td><td> <a href="https://www.owasp.org/index.php/JBroFuzz">https://www.owasp.org/index.php/JBroFuzz</a></td></tr>
 <tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td>
 Diagona and Fugue Icons</td><td> Some icons are copyright (c) Yusuke Kamiyamane <a href="http://p.yusukekamiyamane.com">http://p.yusukekamiyamane.com</a> All rights reserved.</td></tr>
 <tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td>
-Crawljax</td><td> <a href="https://www.crawljax.com">https://www.crawljax.com</a></td></tr>
+Crawljax</td><td> <a href="http://crawljax.com">http://crawljax.com</a></td></tr>
 <tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td>
 RSyntaxTextArea</td><td> <a href="https://bobbylight.github.io/RSyntaxTextArea/">https://bobbylight.github.io/RSyntaxTextArea/</a></td></tr>
 <tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td>
-SwingX</td><td> <a href="https://swingx.java.net/">https://swingx.java.net/</a></td></tr>
+SwingX</td><td></td></tr>
 <tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td>
 HarLib</td><td> <a href="http://www.frogthinker.org/projects/harlib">http://www.frogthinker.org/projects/harlib</a></td></tr>
 <tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td>


### PR DESCRIPTION
Fix links leading to 404 or redirections:
 - Update guttula's twitter account.
 - Remove extra `/` in JBroFuzz link.
 - Remove link to SwingX home, no longer exists.
 - Correct link to Crawljax home (not using HTTPS nor www subdomain).