### PR TITLE
Remove links to parosproxy.org

### DIFF
--- a/src/help/zaphelp/contents/credits.html
+++ b/src/help/zaphelp/contents/credits.html
@@ -220,7 +220,7 @@ Common Weakness Enumeration</td><td><a href="https://cwe.mitre.org/data/index.ht
 <H2>Paros</H2>
 <table>
 <tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td>
-Chinotec Technologies Company</td><td> <a href="http://www.parosproxy.org">http://www.parosproxy.org</a></td></tr>
+Chinotec Technologies Company</td><td> </td></tr>
 </table> 
 
 <H2>Watcher: Passive Web-security Scanner</H2>

--- a/src/help/zaphelp/contents/intro.html
+++ b/src/help/zaphelp/contents/intro.html
@@ -46,7 +46,6 @@ start using ZAP</td></tr>
 <table>
 <tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td><a href="https://www.owasp.org/index.php/ZAP">ZAP homepage</a></td></tr>
 <tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td><a href="https://en.wikipedia.org/wiki/Proxy_server">Wikipedia entry for proxies</a></td></tr>
-<tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td><a href="http://www.parosproxy.org">Paros proxy</a></td></tr>
 </table>
 <br/>
 <p>

--- a/src/help/zaphelp/contents/paros.html
+++ b/src/help/zaphelp/contents/paros.html
@@ -35,7 +35,7 @@ Significant new functionality has been implemented in a separate tree under the 
 <H2>External links</H2>
 <table>
 <tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td>
-http://www.parosproxy.org</td><td>the Paros proxy</td></tr>
+<a href="https://sourceforge.net/projects/paros/">https://sourceforge.net/projects/paros/</a></td><td>the Paros proxy</td></tr>
 </table>
 </BODY>
 </HTML>


### PR DESCRIPTION
Remove links to parosproxy.org, the site is no longer about Paros proxy.
For the Paros Proxy help page link to the project under Source Forge
(which at some point the site was redirecting to).