### PR TITLE
Add new httpSessions endpoints to release notes

### DIFF
--- a/src/help/zaphelp/contents/releases/2_8_0.html
+++ b/src/help/zaphelp/contents/releases/2_8_0.html
@@ -122,6 +122,9 @@ Tells whether or not the active scanner should add a query parameter to GET requ
 <H3>VIEW context / urls</H3>
 Lists the URLs accessed through/by ZAP, that belong to the context with the given name.
 
+<H3>VIEW httpSessions / defaultSessionTokens</H3>
+Gets the default session tokens.
+
 <H3>VIEW script / globalVar</H3>
 Gets the value of the global variable with the given key. Returns an API error (DOES_NOT_EXIST) if no value was previously set.
 
@@ -139,6 +142,15 @@ Gets all the variables (key/value pairs) of the given script. Returns an API err
 
 <H3> ACTION ascan / setOptionAddQueryParam</H3>
  Sets whether or not the active scanner should add a query param to GET requests which do not have parameters to start with.
+
+<H3>ACTION httpSessions / addDefaultSessionToken</H3>
+Adds a default session token with the given name and enabled state.
+
+<H3>ACTION httpSessions / removeDefaultSessionToken</H3>
+Removes the default session token with the given name.
+
+<H3>ACTION httpSessions / setDefaultSessionTokenEnabled</H3>
+Sets whether or not the default session token with the given name is enabled.
 
 <H3>ACTION script / clearGlobalVar</H3>
 Clears the global variable with the given key.


### PR DESCRIPTION
Change Release 2.8.0 page to add the new API httpSessions view/actions
that allow to manage the default session tokens.

Part of zaproxy/zaproxy#4997 - Allow to manage default session tokens