### PR TITLE
Update Rule Configuration options page

### DIFF
--- a/src/help/zaphelp/contents/ui/dialogs/options/ruleconfig.html
+++ b/src/help/zaphelp/contents/ui/dialogs/options/ruleconfig.html
@@ -24,6 +24,12 @@ Cookies included in this list will be ignored when scanning for cookie related i
 <tr><td>rules.csrf.ignorelist</td><td></td><td>A comma separated list of identifiers.
 Any FORMs with a name or ID that matches one of these identifiers will be ignored when scanning for missing Anti-CSRF tokens.
 Only use this feature to ignore FORMs that you know are safe, for example search forms.</td></tr>
+<tr><td>rules.csrf.ignore.attname</td><td></td><td>The name of an HTML attribute that can be used to indicate that a form does
+not need an anti-CSRF Token. If <code>rules.csrf.ignore.attvalue</code> is specified then this must also match the attribute's value. If
+found any related alerts will be raised at INFO level.</td></tr>
+<tr><td>rules.csrf.ignore.attvalue</td><td></td><td>The value of an HTML attribute named by <code>rules.csrf.ignore.attname</code>
+that can be used to indicate that a form does not need an anti-CSRF Token. If found any related alerts will be raised at INFO level.</td></tr>
+<tr><td>rules.domains.trusted</td><td></td><td>A comma separated list of URL regex patterns. Any URLs that match the patterns will be considered trusted domains and the issues ignored.</td></tr>
 </table>
 
 


### PR DESCRIPTION
Add rules `rules.csrf.ignore.attname`, `rules.csrf.ignore.attvalue`,
and `rules.domains.trusted`.

Part of zaproxy/zaproxy#3115 and zaproxy/zaproxy#5041.