### PR TITLE
Update authentication method behaviour on change

### DIFF
--- a/src/help/zaphelp/contents/releases/2_8_0.html
+++ b/src/help/zaphelp/contents/releases/2_8_0.html
@@ -121,6 +121,10 @@ The view will now validate the risk ID, returning an error (ILLEGAL_PARAMETER) i
 
 <H2>ZAP API Changed Endpoints:</H2>
 
+<H3>ACTION authentication / setAuthenticationMethod</H3>
+The action will no longer remove existing users, instead the user is disabled and its credentials reset if the type of
+credentials of the authentication method being set is different.
+
 <H3>ACTION context / excludeContextTechnologies</H3>
 The action will now accept the string with technologies even if there are spaces before or after the names, for example:
 <blockquote><pre><code>

--- a/src/help/zaphelp/contents/ui/dialogs/session/context-auth.html
+++ b/src/help/zaphelp/contents/ui/dialogs/session/context-auth.html
@@ -10,11 +10,11 @@ Session Context Authentication screen
 <H1>Session Context Authentication screen</H1>
 <p>
 This is one of the <a href="contexts.html">Session Context screens</a>
-which allows you to manage the way in which <a href="../../../start/concepts/authentication.html">Authentication</a> is being done for the Context. Note that
-changing the authentication method after Users have been defined will cause them to be deleted, as
-the type of user credentials needs to match the authentication scheme. 
-After selecting the Authentication Method type, the options that need to be configured 
-depend on the Authentication Method.
+which allows you to manage the way in which <a href="../../../start/concepts/authentication.html">Authentication</a> is being done for the Context.
+After selecting the Authentication Method type, the options that need to be configured depend on the Authentication Method.
+<p>
+<strong>Note:</strong> Changing the authentication method after Users have been defined might cause its credentials to be reset,
+as the type of user credentials need to match the authentication scheme. A confirmation dialogue will be shown when that happens.
 
 <h4>Manual Authentication</h4>
 No configuration is needed for this authentication method. <small>Read  


### PR DESCRIPTION
Update release notes (for API endpoint) and the Session Context
Authentication screen to mention that the users are no longer deleted
when the authentication method is changed.

Part of zaproxy/zaproxy#1067 - User conversion between changes of
AuthenticationMethods