### PR TITLE
Add Client Cert CLI and API details to release notes

### DIFF
--- a/src/help/zaphelp/contents/releases/2_8_0.html
+++ b/src/help/zaphelp/contents/releases/2_8_0.html
@@ -18,6 +18,23 @@ ZAP, has now been removed, the same and much more can be achieved with scripts a
 To prevent add-ons (inadvertently) use/override core files ZAP will no longer start (and show an error) if the home and the
 installation directories are the same.
 
+<h3>Client Certificate Handling</h3>
+It is now possible to set the Client Certificate from the command line with the following switches:
+<pre>
+-config certificate.use=true
+-config certificate.pkcs12.path=/path/to/file.p12
+-config certificate.pkcs12.password=WhateverThePasswordIs
+-config certificate.pkcs12.index=1
+-config certificate.persist=true
+</pre>
+<p>
+<code>-config certificate.pkcs12.index</code> is only necessary if the file contains multiple certificates 
+and you wish to use one other than the first. Index values start at zero (0) which is the first certificate
+in the file.<br><br>
+<code>-config certificate.persist=true</code> is only necessary if you would like the settings persisted in ZAP's regular 
+configuration file (so that they apply for subsequent ZAP use).
+</p>
+
 <H2>Changes in Bundled Libraries</H2>
 The following libraries are no longer being bundled with ZAP (core):
 <ul>
@@ -180,8 +197,14 @@ Gets the value of the variable with the given key for the given script. Returns 
 <H3>VIEW script / scriptVars</H3>
 Gets all the variables (key/value pairs) of the given script. Returns an API error (DOES_NOT_EXIST) if no script with the given name exists.
 
-<H3> ACTION ascan / setOptionAddQueryParam</H3>
- Sets whether or not the active scanner should add a query param to GET requests which do not have parameters to start with.
+<H3>ACTION ascan / setOptionAddQueryParam</H3>
+Sets whether or not the active scanner should add a query param to GET requests which do not have parameters to start with.
+
+<H3>ACTION core / enablePKCS12ClientCertificate </H3>
+Enables use of a PKCS12 client certificate for the certificate with the given file system path, password, and optional index.
+
+<H3>ACTION core / disableClientCertificate</H3>
+Disables the option for use of client certificates.
 
 <H3>ACTION httpSessions / addDefaultSessionToken</H3>
 Adds a default session token with the given name and enabled state.


### PR DESCRIPTION
Follow-up to:
https://github.com/zaproxy/zap-core-help/pull/215
https://github.com/zaproxy/zaproxy/pull/5166

In the API section I also removed two spurious spaces on the setOptionAddQueryParam section.