### PR TITLE
Mention deprecation of core alert API endpoints

### DIFF
--- a/src/help/zaphelp/contents/releases/2_8_0.html
+++ b/src/help/zaphelp/contents/releases/2_8_0.html
@@ -145,6 +145,10 @@ The view will now validate the risk ID, returning an error (ILLEGAL_PARAMETER) i
 <H3>VIEW core / numberOfAlerts</H3>
 The view will now validate the risk ID, returning an error (ILLEGAL_PARAMETER) if not valid.
 
+<H2>ZAP API Deprecated Endpoints:</H2>
+
+All alert related core endpoints were deprecated, they are now accessible through a new component <code>alert</code>.
+
 <H2>ZAP API Changed Endpoints:</H2>
 
 <H3>ACTION authentication / setAuthenticationMethod</H3>


### PR DESCRIPTION
Update release notes to mention that the core alert API endpoints were
deprecated.

Done in zaproxy/zaproxy#4833 - Added alert api endpoints