### PR TITLE
Add new autoupdate endpoint to release notes

### DIFF
--- a/src/help/zaphelp/contents/releases/2_8_0.html
+++ b/src/help/zaphelp/contents/releases/2_8_0.html
@@ -177,6 +177,9 @@ Added optional parameters <code>name</code> and <code>overwrite</code>, to allow
 <H3>View ascan / optionAddQueryParam</H3>
 Tells whether or not the active scanner should add a query parameter to GET request that don't have parameters to start with.
 
+<H3>VIEW autoupdate / localAddons</H3>
+Returns a list with all local add-ons, installed or not.
+
 <H3>VIEW context / urls</H3>
 Lists the URLs accessed through/by ZAP, that belong to the context with the given name.
 


### PR DESCRIPTION
Change Release 2.8.0 page to add the new autoupdate view that allows to
get a list with the local add-ons.

Part of zaproxy/zaproxy#5236 - Expose the local add-ons through the ZAP
API