### PR TITLE
Remove ZapVersions configuration

### DIFF
--- a/addOns/addOns.gradle.kts
+++ b/addOns/addOns.gradle.kts
@@ -79,10 +79,6 @@ subprojects {
         wikiGen {
             wikiFilesPrefix.set("Help")
         }
-
-        zapVersions {
-            downloadUrl.set("https://github.com/zaproxy/zap-extensions/releases/download/2.7")
-        }
     }
 
     dependencies {


### PR DESCRIPTION
The generation of the ZapVersions.xml data will be done in the zap-admin
repository when needed.