### PR TITLE
Update proxy config steps

### DIFF
--- a/addOns/help/src/main/javahelp/contents/start/proxies.html
+++ b/addOns/help/src/main/javahelp/contents/start/proxies.html
@@ -25,36 +25,37 @@ Instructions for the latest versions of the most commonly used browsers:
 <tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td>Press the</td><td> 'LAN Settings' button</td></tr>
 <tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td>Follow the</td><td> 'Windows LAN Settings' section below</td></tr>
 </table>
+<strong>Note:</strong> To proxy <code>localhost</code> (and related addresses) with newer Chrome versions (>= 72) the command line argument <code>--proxy-bypass-list=&lt;-loopback&gt;</code> must be provided.
 
 <H3>Firefox (on Windows)</H3>
 <table>
 <tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td>Select the</td><td> 'Tools' menu </td></tr>
 <tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td>Select the</td><td> 'Options..' menu item</td></tr>
-<tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td>Press the</td><td> 'Advanced' button</td></tr>
-<tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td>Select the</td><td> 'Network' tab</td></tr>
+<tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td>Select the</td><td> 'General' panel</td></tr>
+<tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td>Scroll to</td><td> 'Network Settings' section</td></tr>
 <tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td>Press the</td><td> 'Settings...' button</td></tr>
 <tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td>Select the</td><td> 'Manual proxy configuration' radio button</td></tr>
 <tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td>Enter in the</td><td> 'HTTP Proxy:' field the 'Address' you configured in the 
 <a href="../ui/dialogs/options/localproxy.html">Options Local Proxies screen</a></td></tr>
 <tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td>Enter in the</td><td> 'Port' field to the right of the 'HTTP Proxy' field the 'Port' you configured in the 
-<a href="../ui/dialogs/options/localproxy.html">Options Local Proxies screen</a></td></tr>
+<a href="../ui/dialogs/options/localproxy.html">Options Local Proxies screen</a>. Ensure 'SSL Proxy' is also configured, either by selecting 'Use this proxy server for all protocols' or by setting the corresponding values.</td></tr>
 <tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td>Press the</td><td> Connection Setting 'OK' button</td></tr>
 <tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td>Press the</td><td> Options 'OK' button</td></tr>
 </table>
+<strong>Note:</strong> To proxy <code>localhost</code> (and related addresses) with newer Firefox versions (>= 67) the preference <code>network.proxy.allow_hijacking_localhost</code> (accessible through the <code>about:config</code> page) must be set to <code>true</code>.
 
 <H3>Firefox (on Linux)</H3>
 <table>
 <tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td>Select the</td><td>'Edit' menu</td></tr>
 <tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td>Select the</td><td>'Preferences' menu item</td></tr>
-<tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td>Follow the</td><td>instructions above from the 'Advanced' button</td></tr>
+<tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td>Follow the</td><td>instructions above from the 'General' panel</td></tr>
 </table>
 
 <H3>Firefox (on OS X)</H3>
 <table>
 <tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td>Select the</td><td> 'Firefox' menu </td></tr>
 <tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td>Select the</td><td> 'Preferences...' menu item</td></tr>
-<tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td>Press the</td><td> 'Advanced' button</td></tr>
-<tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td>Follow the</td><td> instructions above from the 'Advanced' button</td></tr>
+<tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td>Follow the</td><td> instructions above from the 'General' panel</td></tr>
 </table>
 
 <H3>Internet Explorer 7 and 8</H3>


### PR DESCRIPTION
Mention the requirements to proxy localhost with the newer versions of
Chrome and Firefox.
Use new panel/section names for Firefox steps and mention that SSL Proxy
should be configured as well.