### PR TITLE
Tweak main add-ons page

### DIFF
--- a/addOns/help/src/main/javahelp/contents/addons/introduction.html
+++ b/addOns/help/src/main/javahelp/contents/addons/introduction.html
@@ -3,11 +3,11 @@
 <HEAD>
 <META HTTP-EQUIV="Content-Type" CONTENT="text/html; charset=utf-8">
 <TITLE>
-Add Ons
+Add-ons
 </TITLE>
 </HEAD>
 <BODY BGCOLOR="#ffffff">
-<H1>Add Ons</H1>
+<H1>Add-ons</H1>
 
 <a href="../start/concepts/addons.html">Add-ons</a> add additional functionality to ZAP.<br/><br/>
 

--- a/addOns/help/src/main/javahelp/contents/start/concepts/addons.html
+++ b/addOns/help/src/main/javahelp/contents/start/concepts/addons.html
@@ -19,7 +19,7 @@ You can typically add and remove add-ons to and from the ZAP UI without having t
 Add-ons can provide context sensitive help which is dynamically integrated with the help file.<br/>
 If you are reading this page via a ZAP help file (as opposed to reading it online) then any
 help pages associated with the add-ons you have installed will be available under 
-<a href="../../addon/introduction.html">here</a>.<br/>
+<a href="../../addons/introduction.html">here</a>.<br/>
 
 </p>
 <p>

--- a/addOns/help/src/main/javahelp/index.xml
+++ b/addOns/help/src/main/javahelp/index.xml
@@ -13,7 +13,7 @@
     <indexitem text="active scan dialog" target="ui.dialogs.advascan" />
     <indexitem text="active scan tab" target="ui.tabs.ascan"/>
     <indexitem text="add-ons" target="start.concepts.addons"/>
-    <indexitem text="add-ons" target="addon.introduction"/>
+    <indexitem text="add-ons" target="addons.introduction"/>
     <indexitem text="add alert dialog" target="ui.dialogs.addalert" />
     <indexitem text="add/edit breakpoint dialog" target="ui.dialogs.addbreak" />
     <indexitem text="add note dialog" target="ui.dialogs.addnote" />

--- a/addOns/help/src/main/javahelp/toc.xml
+++ b/addOns/help/src/main/javahelp/toc.xml
@@ -125,7 +125,7 @@
 
    <tocitem text="Command Line" target="cmdline"/>
 
-   <tocitem text="Add Ons" target="addon.introduction" tocid="addons" />
+   <tocitem text="Add-ons" target="addons.introduction" tocid="addons" image="addons.icon" />
    
    <tocitem text="Releases" target="zap.releases">
       <tocitem text="2.9.0" target="zap.releases.2.9.0"/>

--- a/commonFiles/src/main/resources/map.jhm
+++ b/commonFiles/src/main/resources/map.jhm
@@ -78,7 +78,8 @@
         <mapID target="ui.dialogs.spider" url="contents/ui/dialogs/spider.html"/>
         <mapID target="ui.footer" url="contents/ui/footer.html" />
         <mapID target="ui.views" url="contents/ui/views.html" />
-        <mapID target="addon.introduction" url="contents/addon/introduction.html" />
+        <mapID target="addons.introduction" url="contents/addons/introduction.html" />
+        <mapID target="addons.icon" url="contents/images/fugue/block.png" />
         <mapID target="cmdline" url="contents/cmdline.html" />
         <mapID target="zap.paros" url="contents/paros.html" />
         <mapID target="zap.releases" url="contents/releases/releases.html"/>


### PR DESCRIPTION
Rename its directory to be plural (`addons`), tweak the title/heading,
and set the TOC icon to the one used for the Manage Add-ons dialogue.