### PR TITLE
Update add-on plugin, help links, and ZAP version

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Welcome to the OWASP Zed Attack Proxy (ZAP) Desktop User Guide.
 
-This is available both as context sensitive help within ZAP and online here in the [wiki](https://github.com/zaproxy/zap-core-help/wiki).
+This is available both as context sensitive help within ZAP and online in the [ZAP website](https://www.zaproxy.org/docs/desktop/).
 
 The English help files are under the [/addOns/help](https://github.com/zaproxy/zap-core-help/tree/master/addOns/help) directory, so if you'd like to make a change, create a pull request against those files, and they will be updated in the wiki.
 

--- a/addOns/addOns.gradle.kts
+++ b/addOns/addOns.gradle.kts
@@ -4,11 +4,10 @@ import org.zaproxy.gradle.addon.manifest.ManifestExtension
 import org.zaproxy.gradle.addon.misc.ConvertMarkdownToHtml
 import org.zaproxy.gradle.addon.misc.CreateGitHubRelease
 import org.zaproxy.gradle.addon.misc.ExtractLatestChangesFromChangelog
-import org.zaproxy.gradle.addon.wiki.WikiGenExtension
 
 plugins {
     eclipse
-    id("org.zaproxy.add-on") version "0.2.0" apply false
+    id("org.zaproxy.add-on") version "0.3.0" apply false
 }
 
 eclipse {
@@ -34,10 +33,6 @@ subprojects {
         targetCompatibility = JavaVersion.VERSION_1_8
     }
 
-    tasks.named<Jar>("jarJavaHelpDataForWiki") {
-        from(configurations.named("runtimeClasspath").map { it.files.map { file -> if (file.isDirectory) file else project.zipTree(file) } })
-    }
-
     zapAddOn {
         zapVersion.set("2.7.0")
 
@@ -45,12 +40,8 @@ subprojects {
 
         manifest {
             author.set("ZAP Crowdin Team")
-            url.set("https://github.com/zaproxy/zap-core-help/")
+            repo.set("https://github.com/zaproxy/zap-core-help/")
             changesFile.set(tasks.named<ConvertMarkdownToHtml>("generateManifestChanges").flatMap { it.html })
-        }
-
-        wikiGen {
-            wikiFilesPrefix.set("Help")
         }
     }
 
@@ -122,6 +113,3 @@ val Project.zapAddOn: AddOnPluginExtension get() =
 
 fun AddOnPluginExtension.manifest(configure: ManifestExtension.() -> Unit): Unit =
     (this as ExtensionAware).extensions.configure("manifest", configure)
-
-fun AddOnPluginExtension.wikiGen(configure: WikiGenExtension.() -> Unit): Unit =
-    (this as ExtensionAware).extensions.configure("wikiGen", configure)

--- a/addOns/help/help.gradle.kts
+++ b/addOns/help/help.gradle.kts
@@ -7,11 +7,7 @@ zapAddOn {
     addOnStatus.set(AddOnStatus.RELEASE)
 
     manifest {
-        url.set("https://github.com/zaproxy/zap-core-help/wiki/HelpIntro")
-        notBeforeVersion.set("2.8.0")
-    }
-
-    wikiGen {
-        wikiDir.set(file("$rootDir/../zap-core-help-wiki/"))
+        url.set("https://www.zaproxy.org/docs/desktop/")
+        notBeforeVersion.set("2.9.0")
     }
 }


### PR DESCRIPTION
Update add-on plugin to 0.3.0:
 - Specify the repo URL in the add-on manifest.
 - Change info URL to point to the help page.
 - Remove wiki gen configurations, no longer needed.

Set minimum ZAP version to 2.9.0.
Update online help link in the README to the new location.