### PR TITLE
Tweak table and note

### DIFF
--- a/addOns/help/src/main/javahelp/contents/ui/dialogs/options/pscanner.html
+++ b/addOns/help/src/main/javahelp/contents/ui/dialogs/options/pscanner.html
@@ -9,11 +9,8 @@
 	<p>
 		This screen allows you to configure the <a href="../../../start/features/pscan.html">passive
 			scanner</a>.
-	<h2>Configuration option explanation</h2>
+	<h2>Configuration Options</h2>
 	<table border="2">
-		<tr>
-			<th colspan="4">Configuration Options</th>
-		</tr>
 		<tr>
 			<th>Field</th>
 			<th>Details</th>

--- a/addOns/help/src/main/javahelp/contents/ui/dialogs/scanpolicy.html
+++ b/addOns/help/src/main/javahelp/contents/ui/dialogs/scanpolicy.html
@@ -33,8 +33,8 @@ If you select Low then fewer attacks will be used which will be quicker but may 
 If you select High then more attacks will be used which may find more issues but will take longer.<br>
 The Insane level should typically only be used for small parts of an application as it can result in a very large number of 
 attacks being used, which can take a considerable length of time.
-
-<strong>Note:</strong>: Please be aware that use of the moniker "Insane" with regard to scan 
+<p>
+<strong>Note:</strong> Please be aware that use of the moniker "Insane" with regard to scan 
 strength is simply a name chosen to represent the most extreme strength of scanning, it is not a 
 commentary or reference to mental health or personal stability.
 


### PR DESCRIPTION
Move table header in passive scanner options to the previous heading,
tables with multiple headers are not properly rendered when converted
to Markdown.
Remove misplaced colon and add a paragraph to the scan policy dialogue
note.