### PR TITLE
Fix typos

### DIFF
--- a/addOns/help/src/main/javahelp/contents/intro.html
+++ b/addOns/help/src/main/javahelp/contents/intro.html
@@ -10,7 +10,7 @@ The OWASP ZAP Desktop User Guide
 <H1>
 OWASP ZAP Desktop User Guide</H1>
 <p>
-Welcome to the The OWASP Zed Attack Proxy (ZAP) Desktop User Guide.<br/><br/>
+Welcome to the OWASP Zed Attack Proxy (ZAP) Desktop User Guide.<br/><br/>
 This is available both as context sensitive help within ZAP and online at 
 <a href="https://www.zaproxy.org/docs/desktop/">https://www.zaproxy.org/docs/desktop/</a>
 <p>

--- a/addOns/help/src/main/javahelp/contents/ui/dialogs/options/dynsslcert.html
+++ b/addOns/help/src/main/javahelp/contents/ui/dialogs/options/dynsslcert.html
@@ -189,7 +189,7 @@ And yes, that example will work - its the Superfish certificate!
 		serial number 2314, the second one 2315, the third one 2316 and so on.
 		The reason for this is simple: browsers are also caching certificates.
 		When you restart ZAP but don't restart your browser, it could happen,
-		the the browser sees the same certificate but with different serial number.
+		that the browser sees the same certificate but with different serial number.
 		In the end, the browser would complain about and reject the certificate.
 		By using the random offset (internally 48bit random number), the chances
 		are 1 to 281.474.976.710.656 that when restarting ZAP, the serial number

--- a/addOns/help/src/main/javahelp/contents/ui/tabs/response.html
+++ b/addOns/help/src/main/javahelp/contents/ui/tabs/response.html
@@ -15,7 +15,7 @@ highlighted in either the <a href="sites.html">Sites tab</a> or the
 
 Pull downs allow you to select different <a href="../views.html">Views</a> for the Response header and body.<br/><br/>
 
-Note that images are only shown the the <a href="history.html">History tab</a>
+Note that images are only shown in the <a href="history.html">History tab</a>
 if the 'Enable Image in History' flag in the <a href="../tlmenu/view.html">View menu</a> is selected. 
 
 <H2>Right click menu</H2>


### PR DESCRIPTION
Remove (or replace) duplicated "the".
From zaproxy/zaproxy-website#16.