### PR TITLE
Update links

### DIFF
--- a/addOns/help/src/main/javahelp/contents/credits.html
+++ b/addOns/help/src/main/javahelp/contents/credits.html
@@ -177,7 +177,7 @@ People who have made contributions to ZAP over the years, in alphabetical order:
 </table> 
 
 <H2>ZAP Localization</H2>
-ZAP localization is organized via <a href="https://crowdin.net/project/owasp-zap">https://crowdin.net/project/owasp-zap</a>
+ZAP localization is organized via <a href="https://crowdin.com/project/owasp-zap">https://crowdin.com/project/owasp-zap</a>
 <br><br>
 <table>
 <tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td>Azerbaijanian</td><td>Rashad Aliyev www.microphp.com</td></tr>

--- a/addOns/help/src/main/javahelp/contents/intro.html
+++ b/addOns/help/src/main/javahelp/contents/intro.html
@@ -44,7 +44,7 @@ start using ZAP</td></tr>
 
 <H2>External links</H2>
 <table>
-<tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td><a href="https://www.owasp.org/index.php/ZAP">ZAP homepage</a></td></tr>
+<tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td><a href="https://owasp.org/www-project-zap/">OWASP ZAP homepage</a></td></tr>
 <tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td><a href="https://en.wikipedia.org/wiki/Proxy_server">Wikipedia entry for proxies</a></td></tr>
 </table>
 

--- a/addOns/help/src/main/javahelp/contents/releases/1.1.0.html
+++ b/addOns/help/src/main/javahelp/contents/releases/1.1.0.html
@@ -15,7 +15,7 @@ The following changes were made in this release:
 
 <H3>OWASP rebranding</H3>
 ZAP has been accepted as an OWASP project.<br>
-Its homepage is now: https://www.owasp.org/index.php/OWASP_Zed_Attack_Proxy_Project
+Its homepage is now: https://owasp.org/www-project-zap/
 
 <H3>Brute Force</H3>
 The ability to brute force files and directories based on code from the OWASP DirBuster project. <br>

--- a/addOns/help/src/main/javahelp/contents/releases/2.3.0.html
+++ b/addOns/help/src/main/javahelp/contents/releases/2.3.0.html
@@ -46,7 +46,7 @@ You can now run ZAP ‘inline’ i.e. <b>without starting the ZAP UI or a daemon
 The API has been extended to support even more of the ZAP functionality.
 
 <H3>Internationalized help file</H3>
-The help file has been internationalized and is in the process of being translated into many other languages via <a href="https://crowdin.net/project/owasp-zap-help">https://crowdin.net/project/owasp-zap-help</a>. If you use ZAP in one of the many languages we support, then the help files will include all of the available translations for that language while defaulting back to English for phrases that have not yet been translated.<br>
+The help file has been internationalized and is in the process of being translated into many other languages via <a href="https://crowdin.com/project/owasp-zap-help">https://crowdin.com/project/owasp-zap-help</a>. If you use ZAP in one of the many languages we support, then the help files will include all of the available translations for that language while defaulting back to English for phrases that have not yet been translated.<br>
 Languages with a significant amount of translated help pages include:
 <ul>
 <li>Bosnian</li>
@@ -66,7 +66,7 @@ There is also an option to <b>toggle the visibility of the tab names</b> on an o
 
 <H3>More functionality moved to add-ons</H3>
 More of the core functionality has been moved into add-ons which allows us to deliver updates dynamically via the ZAP Marketplace rather than requiring new full releases.<br>
-This includes the language packs, so translations made to the ZAP UI via https://crowdin.net/project/owasp-zap can be downloaded within ZAP or even automatically installed.
+This includes the language packs, so translations made to the ZAP UI via https://crowdin.com/project/owasp-zap can be downloaded within ZAP or even automatically installed.
 
 <H3>New and improved active and passive scanning rules</H3>
 Many of the release quality active and passive scanning rules have been improved. There are new alpha and beta quality rules and many rules have been promoted from alpha to beta and from beta to release quality.

--- a/addOns/help/src/main/javahelp/contents/releases/2.4.0.html
+++ b/addOns/help/src/main/javahelp/contents/releases/2.4.0.html
@@ -139,7 +139,7 @@ Please be aware that the Plugin ID for the External Redirect scanner has changed
 <li>Issue 1325 : Option to delete contexts</li>
 <li>Issue 1326 : Move Ajax Spider Extension from Beta to Release status</li>
 <li>Issue 1333 : ExtensionAntiCSRF ConcurrentModificationException</li>
-<li>Issue 1334 : ZAP does not handle API requests on reused connections leading to UnknownHostException: www.zap.com</li>
+<li>Issue 1334 : ZAP does not handle API requests on reused connections leading to <code>UnknownHostException: www.zap.com</code></li>
 <li>Issue 1335 : NullPointerException while selecting a node in the "Alerts" tab after excluding sites from proxy</li>
 <li>Issue 1339 : Introduce a simple event bus</li>
 <li>Issue 1343 : XContentTypeOptionsScanner Internationalization  Usability</li>


### PR DESCRIPTION
Link to new OWASP ZAP page.
Avoid redirects `crowdin.net` → `crowdin.com`.
Prevent link to `www.zap.com`.

From zaproxy/zaproxy-website#59.