### PR TITLE
Do not set the background colour

### DIFF
--- a/addOns/help/src/main/javahelp/contents/addons/introduction.html
+++ b/addOns/help/src/main/javahelp/contents/addons/introduction.html
@@ -6,7 +6,7 @@
 Add-ons
 </TITLE>
 </HEAD>
-<BODY BGCOLOR="#ffffff">
+<BODY>
 <H1>Add-ons</H1>
 
 <a href="../start/features/addons.html">Add-ons</a> add additional functionality to ZAP.<br/><br/>

--- a/addOns/help/src/main/javahelp/contents/cmdline.html
+++ b/addOns/help/src/main/javahelp/contents/cmdline.html
@@ -6,7 +6,7 @@
 Command Line
 </TITLE>
 </HEAD>
-<BODY BGCOLOR="#ffffff">
+<BODY>
 <H1>Command Line</H1>
 
 To run ZAP via the command line, you will need to locate the ZAP startup script.<br/>

--- a/addOns/help/src/main/javahelp/contents/credits.html
+++ b/addOns/help/src/main/javahelp/contents/credits.html
@@ -6,7 +6,7 @@
 Credits
 </TITLE>
 </HEAD>
-<BODY BGCOLOR="#ffffff">
+<BODY>
 <H1>Credits</H1>
 
 <H2>ZAP Core Team (Current)</H2>

--- a/addOns/help/src/main/javahelp/contents/intro.html
+++ b/addOns/help/src/main/javahelp/contents/intro.html
@@ -6,7 +6,7 @@
 The OWASP ZAP Desktop User Guide
 </TITLE>
 </HEAD>
-<BODY BGCOLOR="#ffffff">
+<BODY>
 <H1>
 OWASP ZAP Desktop User Guide</H1>
 <p>

--- a/addOns/help/src/main/javahelp/contents/paros.html
+++ b/addOns/help/src/main/javahelp/contents/paros.html
@@ -6,7 +6,7 @@
 Paros Proxy
 </TITLE>
 </HEAD>
-<BODY BGCOLOR="#ffffff">
+<BODY>
 <H1>Paros Proxy</H1>
 <p>
 ZAP is a fork of version 3.2.13 of the open source variant of Paros developed by Chinotec Technologies Company.

--- a/addOns/help/src/main/javahelp/contents/releases/1.0.0.html
+++ b/addOns/help/src/main/javahelp/contents/releases/1.0.0.html
@@ -6,7 +6,7 @@
 Release 1.0.0
 </TITLE>
 </HEAD>
-<BODY BGCOLOR="#ffffff">
+<BODY>
 <H1>Release 1.0.0</H1>
 <p>
 The following changes were made in this release:

--- a/addOns/help/src/main/javahelp/contents/releases/1.1.0.html
+++ b/addOns/help/src/main/javahelp/contents/releases/1.1.0.html
@@ -6,7 +6,7 @@
 Release 1.1.0
 </TITLE>
 </HEAD>
-<BODY BGCOLOR="#ffffff">
+<BODY>
 <H1>Release 1.1.0</H1>
 <p>
 The following changes were made in this release:

--- a/addOns/help/src/main/javahelp/contents/releases/1.2.0.html
+++ b/addOns/help/src/main/javahelp/contents/releases/1.2.0.html
@@ -6,7 +6,7 @@
 Release 1.2.0
 </TITLE>
 </HEAD>
-<BODY BGCOLOR="#ffffff">
+<BODY>
 <H1>Release 1.2.0</H1>
 <p>
 The following changes were made in this release:

--- a/addOns/help/src/main/javahelp/contents/releases/1.3.0.html
+++ b/addOns/help/src/main/javahelp/contents/releases/1.3.0.html
@@ -6,7 +6,7 @@
 Release 1.3.0
 </TITLE>
 </HEAD>
-<BODY BGCOLOR="#ffffff">
+<BODY>
 <H1>Release 1.3.0</H1>
 <p>
 The following changes were made in this release:

--- a/addOns/help/src/main/javahelp/contents/releases/1.3.1.html
+++ b/addOns/help/src/main/javahelp/contents/releases/1.3.1.html
@@ -6,7 +6,7 @@
 Release 1.3.1
 </TITLE>
 </HEAD>
-<BODY BGCOLOR="#ffffff">
+<BODY>
 <H1>Release 1.3.1</H1>
 <p>
 The following changes were made in this release:

--- a/addOns/help/src/main/javahelp/contents/releases/1.3.2.html
+++ b/addOns/help/src/main/javahelp/contents/releases/1.3.2.html
@@ -6,7 +6,7 @@
 Release 1.3.2
 </TITLE>
 </HEAD>
-<BODY BGCOLOR="#ffffff">
+<BODY>
 <H1>Release 1.3.2</H1>
 <p>
 The following changes were made in this release:

--- a/addOns/help/src/main/javahelp/contents/releases/1.3.3.html
+++ b/addOns/help/src/main/javahelp/contents/releases/1.3.3.html
@@ -6,7 +6,7 @@
 Release 1.3.3
 </TITLE>
 </HEAD>
-<BODY BGCOLOR="#ffffff">
+<BODY>
 <H1>Release 1.3.3</H1>
 <p>
 The following changes were made in this release:

--- a/addOns/help/src/main/javahelp/contents/releases/1.3.4.html
+++ b/addOns/help/src/main/javahelp/contents/releases/1.3.4.html
@@ -6,7 +6,7 @@
 Release 1.3.4
 </TITLE>
 </HEAD>
-<BODY BGCOLOR="#ffffff">
+<BODY>
 <H1>Release 1.3.4</H1>
 <p>
 The following changes were made in this release:

--- a/addOns/help/src/main/javahelp/contents/releases/1.4.0.html
+++ b/addOns/help/src/main/javahelp/contents/releases/1.4.0.html
@@ -6,7 +6,7 @@
   Release 1.4.0
 </TITLE>
 </HEAD>
-<BODY BGCOLOR="#ffffff">
+<BODY>
 <H1>Release 1.4.0</H1>
 <p>
 The following changes were made in this release:

--- a/addOns/help/src/main/javahelp/contents/releases/1.4.1.html
+++ b/addOns/help/src/main/javahelp/contents/releases/1.4.1.html
@@ -6,7 +6,7 @@
 Release 1.4.1
 </TITLE>
 </HEAD>
-<BODY BGCOLOR="#ffffff">
+<BODY>
 <H1>Release 1.4.1</H1>
 <p>
 The following changes were made in this release:

--- a/addOns/help/src/main/javahelp/contents/releases/2.0.0.html
+++ b/addOns/help/src/main/javahelp/contents/releases/2.0.0.html
@@ -6,7 +6,7 @@
   Release 2.0.0
 </TITLE>
 </HEAD>
-<BODY BGCOLOR="#ffffff">
+<BODY>
 <H1>Release 2.0.0</H1>
 <p>
 The following changes were made in this release:

--- a/addOns/help/src/main/javahelp/contents/releases/2.1.0.html
+++ b/addOns/help/src/main/javahelp/contents/releases/2.1.0.html
@@ -6,7 +6,7 @@
   Release 2.1.0
 </TITLE>
 </HEAD>
-<BODY BGCOLOR="#ffffff">
+<BODY>
 <H1>Release 2.1.0</H1>
 <p>
 The following changes were made in this release:

--- a/addOns/help/src/main/javahelp/contents/releases/2.2.0.html
+++ b/addOns/help/src/main/javahelp/contents/releases/2.2.0.html
@@ -6,7 +6,7 @@
   Release 2.2.0
 </TITLE>
 </HEAD>
-<BODY BGCOLOR="#ffffff">
+<BODY>
 <H1>Release 2.2.0</H1>
 <p>
 The following changes were made in this release:

--- a/addOns/help/src/main/javahelp/contents/releases/2.2.1.html
+++ b/addOns/help/src/main/javahelp/contents/releases/2.2.1.html
@@ -6,7 +6,7 @@
   Release 2.2.1
 </TITLE>
 </HEAD>
-<BODY BGCOLOR="#ffffff">
+<BODY>
 <H1>Release 2.2.1</H1>
 <p>
 The following changes were made in this release:

--- a/addOns/help/src/main/javahelp/contents/releases/2.2.2.html
+++ b/addOns/help/src/main/javahelp/contents/releases/2.2.2.html
@@ -6,7 +6,7 @@
   Release 2.2.2
 </TITLE>
 </HEAD>
-<BODY BGCOLOR="#ffffff">
+<BODY>
 <H1>Release 2.2.2</H1>
 <p>
 The following changes were made in this release:

--- a/addOns/help/src/main/javahelp/contents/releases/2.3.0.html
+++ b/addOns/help/src/main/javahelp/contents/releases/2.3.0.html
@@ -6,7 +6,7 @@
   Release 2.3.0
 </TITLE>
 </HEAD>
-<BODY BGCOLOR="#ffffff">
+<BODY>
 <H1>Release 2.3.0</H1>
 <p>
 The following changes were made in this release:

--- a/addOns/help/src/main/javahelp/contents/releases/2.3.1.html
+++ b/addOns/help/src/main/javahelp/contents/releases/2.3.1.html
@@ -6,7 +6,7 @@
   Release 2.3.1
 </TITLE>
 </HEAD>
-<BODY BGCOLOR="#ffffff">
+<BODY>
 <H1>Release 2.3.1</H1>
 <p>
 The following changes were made in this release:

--- a/addOns/help/src/main/javahelp/contents/releases/2.4.0.html
+++ b/addOns/help/src/main/javahelp/contents/releases/2.4.0.html
@@ -6,7 +6,7 @@
   Release 2.4.0
 </TITLE>
 </HEAD>
-<BODY BGCOLOR="#ffffff">
+<BODY>
 <H1>Release 2.4.0</H1>
 <p>
 The following changes were made in this release:

--- a/addOns/help/src/main/javahelp/contents/releases/2.4.1.html
+++ b/addOns/help/src/main/javahelp/contents/releases/2.4.1.html
@@ -6,7 +6,7 @@
   Release 2.4.1
 </TITLE>
 </HEAD>
-<BODY BGCOLOR="#ffffff">
+<BODY>
 <H1>Release 2.4.1</H1>
 <p>
 This release includes important security fixes - users are urged to upgrade asap.

--- a/addOns/help/src/main/javahelp/contents/releases/2.4.2.html
+++ b/addOns/help/src/main/javahelp/contents/releases/2.4.2.html
@@ -6,7 +6,7 @@
   Release 2.4.2
 </TITLE>
 </HEAD>
-<BODY BGCOLOR="#ffffff">
+<BODY>
 <H1>Release 2.4.2</H1>
 
 <p>

--- a/addOns/help/src/main/javahelp/contents/releases/2.4.3.html
+++ b/addOns/help/src/main/javahelp/contents/releases/2.4.3.html
@@ -6,7 +6,7 @@
   Release 2.4.3
 </TITLE>
 </HEAD>
-<BODY BGCOLOR="#ffffff">
+<BODY>
 <H1>Release 2.4.3</H1>
 
 <p>

--- a/addOns/help/src/main/javahelp/contents/releases/2.5.0.html
+++ b/addOns/help/src/main/javahelp/contents/releases/2.5.0.html
@@ -6,7 +6,7 @@
   Release 2.5.0
 </TITLE>
 </HEAD>
-<BODY BGCOLOR="#ffffff">
+<BODY>
 <H1>Release 2.5.0</H1>
 
 <p>

--- a/addOns/help/src/main/javahelp/contents/releases/2.6.0.html
+++ b/addOns/help/src/main/javahelp/contents/releases/2.6.0.html
@@ -6,7 +6,7 @@
   Release 2.6.0
 </TITLE>
 </HEAD>
-<BODY BGCOLOR="#ffffff">
+<BODY>
 <H1>Release 2.6.0</H1>
 
 This release contains a large number of changes, in particular to the ZAP API.<br>

--- a/addOns/help/src/main/javahelp/contents/releases/2.7.0.html
+++ b/addOns/help/src/main/javahelp/contents/releases/2.7.0.html
@@ -6,7 +6,7 @@
   Release 2.7.0
 </TITLE>
 </HEAD>
-<BODY BGCOLOR="#ffffff">
+<BODY>
 <H1>Release 2.7.0</H1>
 
 This is a bug fix and enhancement release, which requires a minimum of Java 8.<br><br>

--- a/addOns/help/src/main/javahelp/contents/releases/2.8.0.html
+++ b/addOns/help/src/main/javahelp/contents/releases/2.8.0.html
@@ -6,7 +6,7 @@
   Release 2.8.0
 </TITLE>
 </HEAD>
-<BODY BGCOLOR="#ffffff">
+<BODY>
 <H1>Release 2.8.0</H1>
 
 This is a bug fix and enhancement release, which requires a minimum of Java 8. 

--- a/addOns/help/src/main/javahelp/contents/releases/2.9.0.html
+++ b/addOns/help/src/main/javahelp/contents/releases/2.9.0.html
@@ -6,7 +6,7 @@
   Release 2.9.0
 </TITLE>
 </HEAD>
-<BODY BGCOLOR="#ffffff">
+<BODY>
 <H1>Release 2.9.0</H1>
 
 This is a bug fix and enhancement release, which requires a minimum of Java 8. 

--- a/addOns/help/src/main/javahelp/contents/releases/releases.html
+++ b/addOns/help/src/main/javahelp/contents/releases/releases.html
@@ -6,7 +6,7 @@
 Releases
 </TITLE>
 </HEAD>
-<BODY BGCOLOR="#ffffff">
+<BODY>
 <H1>Releases</H1>
 <p>
 The following releases have been made:

--- a/addOns/help/src/main/javahelp/contents/start/checks.html
+++ b/addOns/help/src/main/javahelp/contents/start/checks.html
@@ -6,7 +6,7 @@
 Scanner Rules
 </TITLE>
 </HEAD>
-<BODY BGCOLOR="#ffffff">
+<BODY>
 <H1>Scanner Rules</H1>
 <p>
 ZAP supports both <a href="features/ascan.html">active</a> and 

--- a/addOns/help/src/main/javahelp/contents/start/features/addons.html
+++ b/addOns/help/src/main/javahelp/contents/start/features/addons.html
@@ -6,7 +6,7 @@
 Add-ons
 </TITLE>
 </HEAD>
-<BODY BGCOLOR="#ffffff">
+<BODY>
 <H1>Add-ons</H1>
 <p>
 Add-ons add additional functionality to ZAP.<br/>

--- a/addOns/help/src/main/javahelp/contents/start/features/alerts.html
+++ b/addOns/help/src/main/javahelp/contents/start/features/alerts.html
@@ -6,7 +6,7 @@
 Alerts
 </TITLE>
 </HEAD>
-<BODY BGCOLOR="#ffffff">
+<BODY>
 <H1>Alerts</H1>
 <p>
 An alert is a potential vulnerability and is associated with a specific request.<br/>

--- a/addOns/help/src/main/javahelp/contents/start/features/anticsrf.html
+++ b/addOns/help/src/main/javahelp/contents/start/features/anticsrf.html
@@ -6,7 +6,7 @@
 Anti CSRF Handling
 </TITLE>
 </HEAD>
-<BODY BGCOLOR="#ffffff">
+<BODY>
 <H1>Anti CSRF Tokens</H1>
 <p>
 Anti CSRF tokens are (pseudo) random parameters used to protect against Cross Site Request Forgery (CSRF) attacks.<br>

--- a/addOns/help/src/main/javahelp/contents/start/features/api.html
+++ b/addOns/help/src/main/javahelp/contents/start/features/api.html
@@ -6,7 +6,7 @@
 API
 </TITLE>
 </HEAD>
-<BODY BGCOLOR="#ffffff">
+<BODY>
 <H1>API</H1>
 <p>
 ZAP provides an Application Programming Interface (API) which allows you to interact with ZAP programmatically.

--- a/addOns/help/src/main/javahelp/contents/start/features/ascan.html
+++ b/addOns/help/src/main/javahelp/contents/start/features/ascan.html
@@ -6,7 +6,7 @@
 Active Scan
 </TITLE>
 </HEAD>
-<BODY BGCOLOR="#ffffff">
+<BODY>
 <H1>Active Scan</H1>
 <p>
 Active scanning attempts to find potential vulnerabilities by using

--- a/addOns/help/src/main/javahelp/contents/start/features/authentication.html
+++ b/addOns/help/src/main/javahelp/contents/start/features/authentication.html
@@ -4,7 +4,7 @@
 <META HTTP-EQUIV="Content-Type" CONTENT="text/html; charset=utf-8">
 <title>Authentication</title>
 </head>
-<body bgcolor="#ffffff">
+<body>
 	<h1>Authentication</h1>
 	<p>
 		ZAP handles multiple types of authentication (called <b>Authentication

--- a/addOns/help/src/main/javahelp/contents/start/features/breakpoints.html
+++ b/addOns/help/src/main/javahelp/contents/start/features/breakpoints.html
@@ -6,7 +6,7 @@
 Breakpoints
 </TITLE>
 </HEAD>
-<BODY BGCOLOR="#ffffff">
+<BODY>
 <H1>Breakpoints</H1>
 <p>A breakpoint allows you to intercept a request from your browser and to change it before
 is is submitted to the web application you are testing.<br/> 

--- a/addOns/help/src/main/javahelp/contents/start/features/callbacks.html
+++ b/addOns/help/src/main/javahelp/contents/start/features/callbacks.html
@@ -6,7 +6,7 @@
 Callbacks
 </TITLE>
 </HEAD>
-<BODY BGCOLOR="#ffffff">
+<BODY>
 <H1>Callbacks</H1>
 <p>
 Various ZAP components (scan rules, etc) may leverage payloads which result in HTTP requests back to ZAP. 

--- a/addOns/help/src/main/javahelp/contents/start/features/contexts.html
+++ b/addOns/help/src/main/javahelp/contents/start/features/contexts.html
@@ -6,7 +6,7 @@
 Contexts
 </TITLE>
 </HEAD>
-<BODY BGCOLOR="#ffffff">
+<BODY>
 <H1>Contexts</H1>
 <p>
 Contexts are a way of relating a set of URLs together.<br/>

--- a/addOns/help/src/main/javahelp/contents/start/features/ddc.html
+++ b/addOns/help/src/main/javahelp/contents/start/features/ddc.html
@@ -6,7 +6,7 @@
 Data Driven Content
 </TITLE>
 </HEAD>
-<BODY BGCOLOR="#ffffff">
+<BODY>
 <H1>Data Driven Content</H1>
 <p>
 Data driven content is type of <a href="structmods.html">Structural Modifier</a>

--- a/addOns/help/src/main/javahelp/contents/start/features/features.html
+++ b/addOns/help/src/main/javahelp/contents/start/features/features.html
@@ -6,7 +6,7 @@
 Features
 </TITLE>
 </HEAD>
-<BODY BGCOLOR="#ffffff">
+<BODY>
 <H1>Features</H1>
 ZAP provides the following features:
 <table>

--- a/addOns/help/src/main/javahelp/contents/start/features/filters.html
+++ b/addOns/help/src/main/javahelp/contents/start/features/filters.html
@@ -6,7 +6,7 @@
 Filters
 </TITLE>
 </HEAD>
-<BODY BGCOLOR="#ffffff">
+<BODY>
 <H1>Filters</H1>
 
 Deprecated since ZAP 2.4.0 the Filters functionality, that allowed to change/access some HTTP messages sent/received through

--- a/addOns/help/src/main/javahelp/contents/start/features/globalexcludeurl.html
+++ b/addOns/help/src/main/javahelp/contents/start/features/globalexcludeurl.html
@@ -6,7 +6,7 @@
 Globally Excluded URLs
 </TITLE>
 </HEAD>
-<BODY BGCOLOR="#ffffff">
+<BODY>
 <H1>Globally Excluded URLs</H1>
 
 <p> Globally Excluded URLs are a set of Regular Expressions

--- a/addOns/help/src/main/javahelp/contents/start/features/httpsessions.html
+++ b/addOns/help/src/main/javahelp/contents/start/features/httpsessions.html
@@ -4,7 +4,7 @@
 <META HTTP-EQUIV="Content-Type" CONTENT="text/html; charset=utf-8">
 <title>HTTP Sessions</title>
 </head>
-<body bgcolor="#ffffff">
+<body>
 	<h1>HTTP Sessions</h1>
 	<p>This tool keeps track of the existing HTTP Sessions on a
 		particular Site and allows the Zaproxy user to force all requests to

--- a/addOns/help/src/main/javahelp/contents/start/features/intercept.html
+++ b/addOns/help/src/main/javahelp/contents/start/features/intercept.html
@@ -6,7 +6,7 @@
 Man-in-the-middle Proxy
 </TITLE>
 </HEAD>
-<BODY BGCOLOR="#ffffff">
+<BODY>
 <H1>Man-in-the-middle Proxy</H1>
 <p>
 ZAP is a Man-in-the-middle Proxy. It allows you to see all of the requests you make to a web app

--- a/addOns/help/src/main/javahelp/contents/start/features/modes.html
+++ b/addOns/help/src/main/javahelp/contents/start/features/modes.html
@@ -6,7 +6,7 @@
 Modes
 </TITLE>
 </HEAD>
-<BODY BGCOLOR="#ffffff">
+<BODY>
 <H1>Modes</H1>
 <p>
 ZAP has a 'mode' which can be:

--- a/addOns/help/src/main/javahelp/contents/start/features/notes.html
+++ b/addOns/help/src/main/javahelp/contents/start/features/notes.html
@@ -6,7 +6,7 @@
 Notes
 </TITLE>
 </HEAD>
-<BODY BGCOLOR="#ffffff">
+<BODY>
 <H1>Notes</H1>
 <p>
 A note is any text that you wish to associate with a request.<br/>

--- a/addOns/help/src/main/javahelp/contents/start/features/pscan.html
+++ b/addOns/help/src/main/javahelp/contents/start/features/pscan.html
@@ -6,7 +6,7 @@
 Passive Scan
 </TITLE>
 </HEAD>
-<BODY BGCOLOR="#ffffff">
+<BODY>
 <H1>Passive Scan</H1>
 <p>
 ZAP by default passively scans all HTTP messages (requests and responses) sent to the web application being tested.<br/>

--- a/addOns/help/src/main/javahelp/contents/start/features/scanpolicy.html
+++ b/addOns/help/src/main/javahelp/contents/start/features/scanpolicy.html
@@ -6,7 +6,7 @@
 Scan Policy
 </TITLE>
 </HEAD>
-<BODY BGCOLOR="#ffffff">
+<BODY>
 <H1>Scan Policy</H1>
 <p>
 A scan policy defines exactly which <a href="../checks.html">rules</a> are run as part of an <a href="ascan.html">active scan</a>.<br>

--- a/addOns/help/src/main/javahelp/contents/start/features/scope.html
+++ b/addOns/help/src/main/javahelp/contents/start/features/scope.html
@@ -6,7 +6,7 @@
 Scope
 </TITLE>
 </HEAD>
-<BODY BGCOLOR="#ffffff">
+<BODY>
 <H1>Scope</H1>
 <p>
 The Scope is the set of URLs you are testing, and is defined by the <a href="contexts.html">Contexts</a> 

--- a/addOns/help/src/main/javahelp/contents/start/features/sessionManagement.html
+++ b/addOns/help/src/main/javahelp/contents/start/features/sessionManagement.html
@@ -4,7 +4,7 @@
 <META HTTP-EQUIV="Content-Type" CONTENT="text/html; charset=utf-8">
 <title>Session Management</title>
 </head>
-<body bgcolor="#ffffff">
+<body>
 	<h1>Session Management</h1>
 	<p>
 		ZAP handles multiple types of session management (called <b>Session

--- a/addOns/help/src/main/javahelp/contents/start/features/spider.html
+++ b/addOns/help/src/main/javahelp/contents/start/features/spider.html
@@ -4,7 +4,7 @@
 <META HTTP-EQUIV="Content-Type" CONTENT="text/html; charset=utf-8">
 <title>Spider</title>
 </head>
-<body bgcolor="#ffffff">
+<body>
 	<h1>Spider</h1>
 	<p>The spider is a tool that is used to automatically discover new
 		resources (URLs) on a particular Site. It begins with a list of URLs

--- a/addOns/help/src/main/javahelp/contents/start/features/stats.html
+++ b/addOns/help/src/main/javahelp/contents/start/features/stats.html
@@ -6,7 +6,7 @@
 Statistics
 </TITLE>
 </HEAD>
-<BODY BGCOLOR="#ffffff">
+<BODY>
 <H1>Statistics</H1>
 <p>
 ZAP maintains statistics which can help you understand what is really happening when interacting with large applications.

--- a/addOns/help/src/main/javahelp/contents/start/features/structmods.html
+++ b/addOns/help/src/main/javahelp/contents/start/features/structmods.html
@@ -6,7 +6,7 @@
 Structural Modifiers
 </TITLE>
 </HEAD>
-<BODY BGCOLOR="#ffffff">
+<BODY>
 <H1>Structural Modifiers</H1>
 <p>
 Structural Modifiers are controls which change how ZAP represents the structure of the application.<br>

--- a/addOns/help/src/main/javahelp/contents/start/features/structparams.html
+++ b/addOns/help/src/main/javahelp/contents/start/features/structparams.html
@@ -6,7 +6,7 @@
 Structural Parameters
 </TITLE>
 </HEAD>
-<BODY BGCOLOR="#ffffff">
+<BODY>
 <H1>Structural Parameters</H1>
 <p>
 Structural parameters are a type of <a href="structmods.html">Structural Modifier</a>

--- a/addOns/help/src/main/javahelp/contents/start/features/tags.html
+++ b/addOns/help/src/main/javahelp/contents/start/features/tags.html
@@ -6,7 +6,7 @@
 Tags
 </TITLE>
 </HEAD>
-<BODY BGCOLOR="#ffffff">
+<BODY>
 <H1>Tags</H1>
 <p>
 A tag is short piece of text that you wish to associate with a request.<br/>

--- a/addOns/help/src/main/javahelp/contents/start/features/users.html
+++ b/addOns/help/src/main/javahelp/contents/start/features/users.html
@@ -4,7 +4,7 @@
 <META HTTP-EQUIV="Content-Type" CONTENT="text/html; charset=utf-8">
 <title>Users</title>
 </head>
-<body bgcolor="#ffffff">
+<body>
 	<h1>Users</h1>
 	<p>
 		Users are the ZAP representations of websites/webapps' users. They

--- a/addOns/help/src/main/javahelp/contents/start/pentest.html
+++ b/addOns/help/src/main/javahelp/contents/start/pentest.html
@@ -6,7 +6,7 @@
 A basic penetration test
 </TITLE>
 </HEAD>
-<BODY BGCOLOR="#ffffff">
+<BODY>
 <H1>A basic penetration test</H1>
 <p>
 A basic penetration test is made up of the following steps:

--- a/addOns/help/src/main/javahelp/contents/start/proxies.html
+++ b/addOns/help/src/main/javahelp/contents/start/proxies.html
@@ -6,7 +6,7 @@
 Configuring Proxies
 </TITLE>
 </HEAD>
-<BODY BGCOLOR="#ffffff">
+<BODY>
 <H1>Configuring Proxies</H1>
 <p>
 You will need to configure your browser to use ZAP as a proxy.<br>

--- a/addOns/help/src/main/javahelp/contents/start/start.html
+++ b/addOns/help/src/main/javahelp/contents/start/start.html
@@ -6,7 +6,7 @@
 Getting Started
 </TITLE>
 </HEAD>
-<BODY BGCOLOR="#ffffff">
+<BODY>
 <H1>Getting Started</H1>
 <p>
 The quickest way to get going with ZAP is to use the Quick Start add-on, which is installed by default.<br/>

--- a/addOns/help/src/main/javahelp/contents/ui/dialogs/addalert.html
+++ b/addOns/help/src/main/javahelp/contents/ui/dialogs/addalert.html
@@ -6,7 +6,7 @@
 Add Alert dialog
 </TITLE>
 </HEAD>
-<BODY BGCOLOR="#ffffff">
+<BODY>
 <H1>Add Alert dialog</H1>
 <p>
 This dialog allows you to manually add or change an <a href="../../start/features/alerts.html">Alert</a> associated

--- a/addOns/help/src/main/javahelp/contents/ui/dialogs/addbreak.html
+++ b/addOns/help/src/main/javahelp/contents/ui/dialogs/addbreak.html
@@ -6,7 +6,7 @@
 Add/Edit Breakpoint dialog
 </TITLE>
 </HEAD>
-<BODY BGCOLOR="#ffffff">
+<BODY>
 <H1>Add/Edit Breakpoint dialog</H1>
 <p>
 This dialogue allows you to add and edit <a href="../../start/features/breakpoints.html">HTTP breakpoints</a>.

--- a/addOns/help/src/main/javahelp/contents/ui/dialogs/addnote.html
+++ b/addOns/help/src/main/javahelp/contents/ui/dialogs/addnote.html
@@ -6,7 +6,7 @@
 Add Note dialog
 </TITLE>
 </HEAD>
-<BODY BGCOLOR="#ffffff">
+<BODY>
 <H1>Add Note dialog</H1>
 <p>
 This allows you to add a 

--- a/addOns/help/src/main/javahelp/contents/ui/dialogs/advascan.html
+++ b/addOns/help/src/main/javahelp/contents/ui/dialogs/advascan.html
@@ -6,7 +6,7 @@
 Active Scan dialog
 </TITLE>
 </HEAD>
-<BODY BGCOLOR="#ffffff">
+<BODY>
 <H1>Active Scan dialog</H1>
 <p>
 This dialog launches the <a href="../../start/features/ascan.html">active scanner</a>.<br>

--- a/addOns/help/src/main/javahelp/contents/ui/dialogs/dialogs.html
+++ b/addOns/help/src/main/javahelp/contents/ui/dialogs/dialogs.html
@@ -6,7 +6,7 @@
 Dialogs
 </TITLE>
 </HEAD>
-<BODY BGCOLOR="#ffffff">
+<BODY>
 <H1>Dialogs</H1>
 The UI includes the following dialogs or popups:
 <table>

--- a/addOns/help/src/main/javahelp/contents/ui/dialogs/enc_dec.html
+++ b/addOns/help/src/main/javahelp/contents/ui/dialogs/enc_dec.html
@@ -6,7 +6,7 @@
 Encode / Decode / Hash dialog
 </TITLE>
 </HEAD>
-<BODY BGCOLOR="#ffffff">
+<BODY>
 <H1>Encode / Decode / Hash dialog</H1>
 <p>
 This allows you to encode, decode or hash text.

--- a/addOns/help/src/main/javahelp/contents/ui/dialogs/find.html
+++ b/addOns/help/src/main/javahelp/contents/ui/dialogs/find.html
@@ -6,7 +6,7 @@
 Find dialog
 </TITLE>
 </HEAD>
-<BODY BGCOLOR="#ffffff">
+<BODY>
 <H1>Find dialog</H1>
 <p>
 This allows you to find the text you enter in the selected tab.

--- a/addOns/help/src/main/javahelp/contents/ui/dialogs/hist_filter.html
+++ b/addOns/help/src/main/javahelp/contents/ui/dialogs/hist_filter.html
@@ -6,7 +6,7 @@
 History Filter dialog
 </TITLE>
 </HEAD>
-<BODY BGCOLOR="#ffffff">
+<BODY>
 <H1>History Filter dialog</H1>
 <p>
 This dialog allows you to restrict which requests are displayed in the <a href="../tabs/history.html">History tab</a>.<br/>

--- a/addOns/help/src/main/javahelp/contents/ui/dialogs/man_req.html
+++ b/addOns/help/src/main/javahelp/contents/ui/dialogs/man_req.html
@@ -6,7 +6,7 @@
 Manual Request Editor dialog
 </TITLE>
 </HEAD>
-<BODY BGCOLOR="#ffffff">
+<BODY>
 <H1>Manual Request Editor dialog</H1>
 
 This dialog allows you to create a request from scratch which will be submitted to the specified target,

--- a/addOns/help/src/main/javahelp/contents/ui/dialogs/manageaddons.html
+++ b/addOns/help/src/main/javahelp/contents/ui/dialogs/manageaddons.html
@@ -6,7 +6,7 @@
 Manage Add-ons
 </TITLE>
 </HEAD>
-<BODY BGCOLOR="#ffffff">
+<BODY>
 <H1>Manage Add-ons</H1>
 <p>
 This allows you to manage the <a href="../../start/features/addons.html">add-ons</a>

--- a/addOns/help/src/main/javahelp/contents/ui/dialogs/managetags.html
+++ b/addOns/help/src/main/javahelp/contents/ui/dialogs/managetags.html
@@ -6,7 +6,7 @@
 Manage Tags dialog
 </TITLE>
 </HEAD>
-<BODY BGCOLOR="#ffffff">
+<BODY>
 <H1>Manage Tags dialog</H1>
 <p>
 This allows you to manage the <a href="../../start/features/tags.html">tags</a>

--- a/addOns/help/src/main/javahelp/contents/ui/dialogs/options/alert.html
+++ b/addOns/help/src/main/javahelp/contents/ui/dialogs/options/alert.html
@@ -6,7 +6,7 @@
 Options Alerts screen
 </TITLE>
 </HEAD>
-<BODY BGCOLOR="#ffffff">
+<BODY>
 <H1>Options Alerts screen</H1>
 <p>
 This screen allows you to configure the alerts options:

--- a/addOns/help/src/main/javahelp/contents/ui/dialogs/options/anticsrf.html
+++ b/addOns/help/src/main/javahelp/contents/ui/dialogs/options/anticsrf.html
@@ -6,7 +6,7 @@
 Options Anti CRSF screen
 </TITLE>
 </HEAD>
-<BODY BGCOLOR="#ffffff">
+<BODY>
 <H1>Options Anti CRSF Tokens screen</H1>
 <p>
 This screen allows you to configure the <a href="../../../start/features/anticsrf.html">anti CSRF tokens </a> options:

--- a/addOns/help/src/main/javahelp/contents/ui/dialogs/options/api.html
+++ b/addOns/help/src/main/javahelp/contents/ui/dialogs/options/api.html
@@ -6,7 +6,7 @@
 Options API screen
 </TITLE>
 </HEAD>
-<BODY BGCOLOR="#ffffff">
+<BODY>
 <H1>Options API screen</H1>
 <p>
 This screen allows you to configure the <a href="../../../start/features/api.html">API</a> options:

--- a/addOns/help/src/main/javahelp/contents/ui/dialogs/options/ascan.html
+++ b/addOns/help/src/main/javahelp/contents/ui/dialogs/options/ascan.html
@@ -6,7 +6,7 @@
 Options Active Scan screen
 </TITLE>
 </HEAD>
-<BODY BGCOLOR="#ffffff">
+<BODY>
 <H1>Options Active Scan screen</H1>
 <p>
 This screen allows you to configure the <a href="../../../start/features/ascan.html">active scan</a> options:

--- a/addOns/help/src/main/javahelp/contents/ui/dialogs/options/ascaninput.html
+++ b/addOns/help/src/main/javahelp/contents/ui/dialogs/options/ascaninput.html
@@ -6,7 +6,7 @@
 Options Active Scan Input Vectors screen
 </TITLE>
 </HEAD>
-<BODY BGCOLOR="#ffffff">
+<BODY>
 <H1>Options Active Scan Input Vectors screen</H1>
 <p>
 This screen allows you to configure the <a href="../../../start/features/ascan.html">active scan</a> input vectors.<br>

--- a/addOns/help/src/main/javahelp/contents/ui/dialogs/options/breakpoints.html
+++ b/addOns/help/src/main/javahelp/contents/ui/dialogs/options/breakpoints.html
@@ -6,7 +6,7 @@
 Options Breakpoints screen
 </TITLE>
 </HEAD>
-<BODY BGCOLOR="#ffffff">
+<BODY>
 <H1>Options Breakpoints screen</H1>
 <p>
 This screen allows you to configure the <a href="../../../start/features/breakpoints.html">breakpoint</a> options:

--- a/addOns/help/src/main/javahelp/contents/ui/dialogs/options/callback.html
+++ b/addOns/help/src/main/javahelp/contents/ui/dialogs/options/callback.html
@@ -6,7 +6,7 @@
 Options Callback Address screen
 </TITLE>
 </HEAD>
-<BODY BGCOLOR="#ffffff">
+<BODY>
 <H1>Options Callback Address screen</H1>
 <p>
 The Callback Address screen allows you to configure the address used to detect vulnerabilities that allow an attacker to call remote URLs.<br>

--- a/addOns/help/src/main/javahelp/contents/ui/dialogs/options/certificate.html
+++ b/addOns/help/src/main/javahelp/contents/ui/dialogs/options/certificate.html
@@ -6,7 +6,7 @@
 Options Client Certificate screen
 </TITLE>
 </HEAD>
-<BODY BGCOLOR="#ffffff">
+<BODY>
 <H1>Options Client Certificate screen</H1>
 <p>
 The Client Certificate screen allows you to add a client certificate for ZAP to use when testing applications

--- a/addOns/help/src/main/javahelp/contents/ui/dialogs/options/checkforupdates.html
+++ b/addOns/help/src/main/javahelp/contents/ui/dialogs/options/checkforupdates.html
@@ -6,7 +6,7 @@
 Options Check for Updates screen
 </TITLE>
 </HEAD>
-<BODY BGCOLOR="#ffffff">
+<BODY>
 <H1>Options Check for Updates screen</H1>
 <p>
 This screen allows you to configure whether ZAP checks to see if you are running

--- a/addOns/help/src/main/javahelp/contents/ui/dialogs/options/connection.html
+++ b/addOns/help/src/main/javahelp/contents/ui/dialogs/options/connection.html
@@ -6,7 +6,7 @@
 Options Connection screen
 </TITLE>
 </HEAD>
-<BODY BGCOLOR="#ffffff">
+<BODY>
 <H1>Options Connection screen</H1>
 <p>
 The Options Connection screen allows you to configure the ZAP connection options:

--- a/addOns/help/src/main/javahelp/contents/ui/dialogs/options/database.html
+++ b/addOns/help/src/main/javahelp/contents/ui/dialogs/options/database.html
@@ -6,7 +6,7 @@
 Options Database screen
 </TITLE>
 </HEAD>
-<BODY BGCOLOR="#ffffff">
+<BODY>
 <H1>Options Database screen</H1>
 <p>
 This screen allows you to configure the database options:

--- a/addOns/help/src/main/javahelp/contents/ui/dialogs/options/dynsslcert.html
+++ b/addOns/help/src/main/javahelp/contents/ui/dialogs/options/dynsslcert.html
@@ -6,7 +6,7 @@
 Dynamic SSL Certificates
 </TITLE>
 </HEAD>
-<BODY BGCOLOR="#ffffff">
+<BODY>
 <H1>Option Dynamic SSL Certificates</H1>
 	<p>
 	OWASP ZAP allows you to transparently decrypt SSL connections.

--- a/addOns/help/src/main/javahelp/contents/ui/dialogs/options/ext.html
+++ b/addOns/help/src/main/javahelp/contents/ui/dialogs/options/ext.html
@@ -4,7 +4,7 @@
 <META HTTP-EQUIV="Content-Type" CONTENT="text/html; charset=utf-8">
 <TITLE>Options Extensions screen</TITLE>
 </HEAD>
-<BODY BGCOLOR="#ffffff">
+<BODY>
 	<H1>Options Extensions screen</H1>
 	<p>This screen allows you to enable/disable extensions that are
 		available to ZAP, either core or added by <a href="../../../start/features/addons.html">add-ons</a>.</p>

--- a/addOns/help/src/main/javahelp/contents/ui/dialogs/options/globalexcludeurl.html
+++ b/addOns/help/src/main/javahelp/contents/ui/dialogs/options/globalexcludeurl.html
@@ -6,7 +6,7 @@
 Options Global Exclude URL screen
 </TITLE>
 </HEAD>
-<BODY BGCOLOR="#ffffff">
+<BODY>
 <H1>Options Global Exclude URL screen</H1>
 
 <p> This screen allows you to configure the <a

--- a/addOns/help/src/main/javahelp/contents/ui/dialogs/options/httpsessions.html
+++ b/addOns/help/src/main/javahelp/contents/ui/dialogs/options/httpsessions.html
@@ -4,7 +4,7 @@
 <META HTTP-EQUIV="Content-Type" CONTENT="text/html; charset=utf-8">
 <TITLE>Options HTTP Sessions screen</TITLE>
 </HEAD>
-<BODY BGCOLOR="#ffffff">
+<BODY>
 	<H1>Options HTTP Sessions screen</H1>
 	<p>
 		This screen allows you to configure the <a

--- a/addOns/help/src/main/javahelp/contents/ui/dialogs/options/jvm.html
+++ b/addOns/help/src/main/javahelp/contents/ui/dialogs/options/jvm.html
@@ -6,7 +6,7 @@
 Options JVM screen
 </TITLE>
 </HEAD>
-<BODY BGCOLOR="#ffffff">
+<BODY>
 <H1>Options JVM screen</H1>
 <p>
 This screen allows you to configure the JVM options used when starting ZAP.

--- a/addOns/help/src/main/javahelp/contents/ui/dialogs/options/keyboard.html
+++ b/addOns/help/src/main/javahelp/contents/ui/dialogs/options/keyboard.html
@@ -6,7 +6,7 @@
 Options Keyboard screen
 </TITLE>
 </HEAD>
-<BODY BGCOLOR="#ffffff">
+<BODY>
 <H1>Options Keyboard screen</H1>
 <p>
 This screen allows you to configure keyboard shortcuts for all of the ZAP menus.

--- a/addOns/help/src/main/javahelp/contents/ui/dialogs/options/language.html
+++ b/addOns/help/src/main/javahelp/contents/ui/dialogs/options/language.html
@@ -6,7 +6,7 @@
 Options language screen
 </TITLE>
 </HEAD>
-<BODY BGCOLOR="#ffffff">
+<BODY>
 <H1>Options language screen</H1>
 
 The language screen allows you to configure:

--- a/addOns/help/src/main/javahelp/contents/ui/dialogs/options/localproxy.html
+++ b/addOns/help/src/main/javahelp/contents/ui/dialogs/options/localproxy.html
@@ -6,7 +6,7 @@
 Options Local Proxies screen
 </TITLE>
 </HEAD>
-<BODY BGCOLOR="#ffffff">
+<BODY>
 <H1>Options Local Proxies screen</H1>
 <p>
 This screen allows you to configure the addresses and ports 

--- a/addOns/help/src/main/javahelp/contents/ui/dialogs/options/options.html
+++ b/addOns/help/src/main/javahelp/contents/ui/dialogs/options/options.html
@@ -6,7 +6,7 @@
 Options dialog
 </TITLE>
 </HEAD>
-<BODY BGCOLOR="#ffffff">
+<BODY>
 <H1>Options dialog</H1>
 The Options dialog allows you to configure ZAP.<br/>
 It include the following screens:

--- a/addOns/help/src/main/javahelp/contents/ui/dialogs/options/pscan.html
+++ b/addOns/help/src/main/javahelp/contents/ui/dialogs/options/pscan.html
@@ -6,7 +6,7 @@
 Options Passive Scan Tags screen
 </TITLE>
 </HEAD>
-<BODY BGCOLOR="#ffffff">
+<BODY>
 <H1>Options Passive Scan Tags screen</H1>
 <p>
 This screen allows you to configure the <a href="../../../start/features/tags.html">tags</a> 

--- a/addOns/help/src/main/javahelp/contents/ui/dialogs/options/pscanner.html
+++ b/addOns/help/src/main/javahelp/contents/ui/dialogs/options/pscanner.html
@@ -4,7 +4,7 @@
 <META HTTP-EQUIV="Content-Type" CONTENT="text/html; charset=utf-8">
 <TITLE>Options Passive Scanner Screen</TITLE>
 </HEAD>
-<BODY BGCOLOR="#ffffff">
+<BODY>
 	<H1>Options Passive Scanner screen</H1>
 	<p>
 		This screen allows you to configure the <a href="../../../start/features/pscan.html">passive

--- a/addOns/help/src/main/javahelp/contents/ui/dialogs/options/pscanrules.html
+++ b/addOns/help/src/main/javahelp/contents/ui/dialogs/options/pscanrules.html
@@ -6,7 +6,7 @@
 Options Passive Scan Rules Screen
 </TITLE>
 </HEAD>
-<BODY BGCOLOR="#ffffff">
+<BODY>
 <H1>Options Passive Scan Rules Screen</H1>
 <p>
 This screen allows you to configure the <a href="../../../start/features/pscan.html">passive scan</a> rules.<br>

--- a/addOns/help/src/main/javahelp/contents/ui/dialogs/options/ruleconfig.html
+++ b/addOns/help/src/main/javahelp/contents/ui/dialogs/options/ruleconfig.html
@@ -6,7 +6,7 @@
 Options Rule Configuration screen
 </TITLE>
 </HEAD>
-<BODY BGCOLOR="#ffffff">
+<BODY>
 <H1>Options Rule Configuration screen</H1>
 <p>
 This screen allows you to configure the behaviour of specific active and passive scan rules.

--- a/addOns/help/src/main/javahelp/contents/ui/dialogs/options/script.html
+++ b/addOns/help/src/main/javahelp/contents/ui/dialogs/options/script.html
@@ -6,7 +6,7 @@
 Options Scripts screen
 </TITLE>
 </HEAD>
-<BODY BGCOLOR="#ffffff">
+<BODY>
 <H1>Options Scripts screen</H1>
 <p>
 This screen allows you to configure the script options:

--- a/addOns/help/src/main/javahelp/contents/ui/dialogs/options/search.html
+++ b/addOns/help/src/main/javahelp/contents/ui/dialogs/options/search.html
@@ -6,7 +6,7 @@
 Options Search screen
 </TITLE>
 </HEAD>
-<BODY BGCOLOR="#ffffff">
+<BODY>
 <H1>Options Search screen</H1>
 <p>
 This screen allows you to configure the search options:

--- a/addOns/help/src/main/javahelp/contents/ui/dialogs/options/spider.html
+++ b/addOns/help/src/main/javahelp/contents/ui/dialogs/options/spider.html
@@ -4,7 +4,7 @@
 <META HTTP-EQUIV="Content-Type" CONTENT="text/html; charset=utf-8">
 <title>Options Spider screen</title>
 </head>
-<body bgcolor="#ffffff">
+<body>
 	<h1>Options Spider screen</h1>
 	<p>
 		This screen allows you to configure the <a

--- a/addOns/help/src/main/javahelp/contents/ui/dialogs/options/stats.html
+++ b/addOns/help/src/main/javahelp/contents/ui/dialogs/options/stats.html
@@ -6,7 +6,7 @@
 Options Statistics screen
 </TITLE>
 </HEAD>
-<BODY BGCOLOR="#ffffff">
+<BODY>
 <H1>Options Statistics screen</H1>
 <p>
 This screen allows you to configure the <a href="../../../start/features/stats.html">statistics</a> 

--- a/addOns/help/src/main/javahelp/contents/ui/dialogs/options/view.html
+++ b/addOns/help/src/main/javahelp/contents/ui/dialogs/options/view.html
@@ -6,7 +6,7 @@
 Options Display screen
 </TITLE>
 </HEAD>
-<BODY BGCOLOR="#ffffff">
+<BODY>
 <H1>Options Display screen</H1>
 <p>
 The Display screen allows you to configure:

--- a/addOns/help/src/main/javahelp/contents/ui/dialogs/persistsession.html
+++ b/addOns/help/src/main/javahelp/contents/ui/dialogs/persistsession.html
@@ -6,7 +6,7 @@
 Persist Session dialog
 </TITLE>
 </HEAD>
-<BODY BGCOLOR="#ffffff">
+<BODY>
 <H1>Persist Session dialog</H1>
 
 This dialog is shown by default whenever you start a new session, which always happens when ZAP starts.<br>

--- a/addOns/help/src/main/javahelp/contents/ui/dialogs/resend.html
+++ b/addOns/help/src/main/javahelp/contents/ui/dialogs/resend.html
@@ -6,7 +6,7 @@
 Resend dialog
 </TITLE>
 </HEAD>
-<BODY BGCOLOR="#ffffff">
+<BODY>
 <H1>Resend dialog</H1>
 
 Moved to <a href="man_req.html">Manual Request Editor dialogue</a>

--- a/addOns/help/src/main/javahelp/contents/ui/dialogs/scanpolicy.html
+++ b/addOns/help/src/main/javahelp/contents/ui/dialogs/scanpolicy.html
@@ -6,7 +6,7 @@
 Scan Policy Dialog
 </TITLE>
 </HEAD>
-<BODY BGCOLOR="#ffffff">
+<BODY>
 <H1>Scan Policy Dialog</H1>
 <p>
 This allows you to enable and disable the rules that are run when performing an <a href="../../start/features/ascan.html">active scan</a>.<br>

--- a/addOns/help/src/main/javahelp/contents/ui/dialogs/scanpolicymgr.html
+++ b/addOns/help/src/main/javahelp/contents/ui/dialogs/scanpolicymgr.html
@@ -6,7 +6,7 @@
 Scan Policy Manager dialog
 </TITLE>
 </HEAD>
-<BODY BGCOLOR="#ffffff">
+<BODY>
 <H1>Scan Policy Manager dialog</H1>
 <p>
 This allows you to manage the <a href="../../start/features/scanpolicy.html">scan policies</a> that define the rules that are run when 

--- a/addOns/help/src/main/javahelp/contents/ui/dialogs/scanprogress.html
+++ b/addOns/help/src/main/javahelp/contents/ui/dialogs/scanprogress.html
@@ -6,7 +6,7 @@
 Scan Progress Dialog
 </TITLE>
 </HEAD>
-<BODY BGCOLOR="#ffffff">
+<BODY>
 <H1>Scan Progress Dialog</H1>
 <p>
 This shows you the status of an <a href="../../start/features/ascan.html">active scan</a>.<br>

--- a/addOns/help/src/main/javahelp/contents/ui/dialogs/session/context-auth.html
+++ b/addOns/help/src/main/javahelp/contents/ui/dialogs/session/context-auth.html
@@ -6,7 +6,7 @@
 Session Context Authentication screen
 </TITLE>
 </HEAD>
-<BODY BGCOLOR="#ffffff">
+<BODY>
 <H1>Session Context Authentication screen</H1>
 <p>
 This is one of the <a href="contexts.html">Session Context screens</a>

--- a/addOns/help/src/main/javahelp/contents/ui/dialogs/session/context-struct.html
+++ b/addOns/help/src/main/javahelp/contents/ui/dialogs/session/context-struct.html
@@ -6,7 +6,7 @@
 Session Context Structure screen
 </TITLE>
 </HEAD>
-<BODY BGCOLOR="#ffffff">
+<BODY>
 <H1>Session Context Structure screen</H1>
 <p>
 This is one of the <a href="contexts.html">Session Context screens</a>

--- a/addOns/help/src/main/javahelp/contents/ui/dialogs/session/contexts.html
+++ b/addOns/help/src/main/javahelp/contents/ui/dialogs/session/contexts.html
@@ -6,7 +6,7 @@
 Session Context screens
 </TITLE>
 </HEAD>
-<BODY BGCOLOR="#ffffff">
+<BODY>
 <H1>Session Context screens</H1>
 <p>
 These screens allows you manage <a href="../../../start/features/contexts.html">contexts</a>.

--- a/addOns/help/src/main/javahelp/contents/ui/dialogs/session/sessprop.html
+++ b/addOns/help/src/main/javahelp/contents/ui/dialogs/session/sessprop.html
@@ -6,7 +6,7 @@
 Session Properties dialog
 </TITLE>
 </HEAD>
-<BODY BGCOLOR="#ffffff">
+<BODY>
 <H1>Session Properties dialog</H1>
 <p>
 This allows you to set the session properties and is made up of the following screens:

--- a/addOns/help/src/main/javahelp/contents/ui/dialogs/spider.html
+++ b/addOns/help/src/main/javahelp/contents/ui/dialogs/spider.html
@@ -6,7 +6,7 @@
 Spider dialog
 </TITLE>
 </HEAD>
-<BODY BGCOLOR="#ffffff">
+<BODY>
 <H1>Spider dialog</H1>
 <p>
 This dialog launches the <a href="../../start/features/spider.html">spider</a>.<br>

--- a/addOns/help/src/main/javahelp/contents/ui/footer.html
+++ b/addOns/help/src/main/javahelp/contents/ui/footer.html
@@ -6,7 +6,7 @@
 Footer
 </TITLE>
 </HEAD>
-<BODY BGCOLOR="#ffffff">
+<BODY>
 <H1>Footer</H1>
 <p>
 This footer displays counts of the High, Medium, Low and Informational 

--- a/addOns/help/src/main/javahelp/contents/ui/overview.html
+++ b/addOns/help/src/main/javahelp/contents/ui/overview.html
@@ -6,7 +6,7 @@
 Desktop UI Overview
 </TITLE>
 </HEAD>
-<BODY BGCOLOR="#ffffff">
+<BODY>
 <H1>Desktop UI Overview</H1>
 The Desktop UI is made up of:
 <table>

--- a/addOns/help/src/main/javahelp/contents/ui/tabs/alerts.html
+++ b/addOns/help/src/main/javahelp/contents/ui/tabs/alerts.html
@@ -6,7 +6,7 @@
 Alerts tab
 </TITLE>
 </HEAD>
-<BODY BGCOLOR="#ffffff">
+<BODY>
 <H1>Alerts tab</H1>
 
 <p>

--- a/addOns/help/src/main/javahelp/contents/ui/tabs/ascan.html
+++ b/addOns/help/src/main/javahelp/contents/ui/tabs/ascan.html
@@ -6,7 +6,7 @@
 Active Scan tab
 </TITLE>
 </HEAD>
-<BODY BGCOLOR="#ffffff">
+<BODY>
 <H1>Active Scan tab</H1>
 
 The Active Scan tab allows you to perform an <a href="../../start/features/ascan.html">active scan</a>.<br> 

--- a/addOns/help/src/main/javahelp/contents/ui/tabs/break.html
+++ b/addOns/help/src/main/javahelp/contents/ui/tabs/break.html
@@ -6,7 +6,7 @@
 Break tab
 </TITLE>
 </HEAD>
-<BODY BGCOLOR="#ffffff">
+<BODY>
 <H1>Break tab</H1>
 <p>
 The Break tab allows you to change a request or response when it has been caught by ZAP via

--- a/addOns/help/src/main/javahelp/contents/ui/tabs/breakpoints.html
+++ b/addOns/help/src/main/javahelp/contents/ui/tabs/breakpoints.html
@@ -6,7 +6,7 @@
 Breakpoints tab
 </TITLE>
 </HEAD>
-<BODY BGCOLOR="#ffffff">
+<BODY>
 <H1>Breakpoints tab</H1>
 
 <p>The Breakpoints tab shows you all of the 

--- a/addOns/help/src/main/javahelp/contents/ui/tabs/callbacks.html
+++ b/addOns/help/src/main/javahelp/contents/ui/tabs/callbacks.html
@@ -6,7 +6,7 @@
 Callbacks tab
 </TITLE>
 </HEAD>
-<BODY BGCOLOR="#ffffff">
+<BODY>
 <H1>Callbacks tab</H1>
 
 <p>This tab shows a summary of the callback requests ZAP has received.</p>

--- a/addOns/help/src/main/javahelp/contents/ui/tabs/history.html
+++ b/addOns/help/src/main/javahelp/contents/ui/tabs/history.html
@@ -6,7 +6,7 @@
 History tab
 </TITLE>
 </HEAD>
-<BODY BGCOLOR="#ffffff">
+<BODY>
 <H1>History tab</H1>
 <p>
 The History tab shows a list of all of the requests in the order in which they were made.<br/>

--- a/addOns/help/src/main/javahelp/contents/ui/tabs/httpsessions.html
+++ b/addOns/help/src/main/javahelp/contents/ui/tabs/httpsessions.html
@@ -4,7 +4,7 @@
 <META HTTP-EQUIV="Content-Type" CONTENT="text/html; charset=utf-8">
 <title>HTTP Sessions tab</title>
 </head>
-<body bgcolor="#ffffff">
+<body>
 	<h1>HTTP Sessions tab</h1>
 	<p>
 		This tab shows you the set of identified HTTP sessions for each Site,

--- a/addOns/help/src/main/javahelp/contents/ui/tabs/output.html
+++ b/addOns/help/src/main/javahelp/contents/ui/tabs/output.html
@@ -6,7 +6,7 @@
 Output tab
 </TITLE>
 </HEAD>
-<BODY BGCOLOR="#ffffff">
+<BODY>
 <H1>Output tab</H1>
 
 <p>This show various informational messages.</p>

--- a/addOns/help/src/main/javahelp/contents/ui/tabs/params.html
+++ b/addOns/help/src/main/javahelp/contents/ui/tabs/params.html
@@ -6,7 +6,7 @@
 Params tab
 </TITLE>
 </HEAD>
-<BODY BGCOLOR="#ffffff">
+<BODY>
 <H1>Params tab</H1>
 
 <p>This shows a summary of the parameters and response header fields a site uses.</p>

--- a/addOns/help/src/main/javahelp/contents/ui/tabs/request.html
+++ b/addOns/help/src/main/javahelp/contents/ui/tabs/request.html
@@ -6,7 +6,7 @@
 Request tab
 </TITLE>
 </HEAD>
-<BODY BGCOLOR="#ffffff">
+<BODY>
 <H1>Request tab</H1>
 <p>
 The Request tab shows you the data sent by your browser for the request that you have

--- a/addOns/help/src/main/javahelp/contents/ui/tabs/response.html
+++ b/addOns/help/src/main/javahelp/contents/ui/tabs/response.html
@@ -6,7 +6,7 @@
 Response tab
 </TITLE>
 </HEAD>
-<BODY BGCOLOR="#ffffff">
+<BODY>
 <H1>Response tab</H1>
 <p>
 The Response tab shows you the data sent to your browser for the request that you have

--- a/addOns/help/src/main/javahelp/contents/ui/tabs/search.html
+++ b/addOns/help/src/main/javahelp/contents/ui/tabs/search.html
@@ -6,7 +6,7 @@
 Search tab
 </TITLE>
 </HEAD>
-<BODY BGCOLOR="#ffffff">
+<BODY>
 <H1>Search tab</H1>
 
 <p>The Search tab allows you to search for regular expressions in all of the

--- a/addOns/help/src/main/javahelp/contents/ui/tabs/sites.html
+++ b/addOns/help/src/main/javahelp/contents/ui/tabs/sites.html
@@ -6,7 +6,7 @@
 Sites tab
 </TITLE>
 </HEAD>
-<BODY BGCOLOR="#ffffff">
+<BODY>
 <H1>Sites tab</H1>
 The sites tab contains two trees, one for <a href="../../start/features/contexts.html">contexts</a> and the other for the sites accessed by/through ZAP.
 

--- a/addOns/help/src/main/javahelp/contents/ui/tabs/spider.html
+++ b/addOns/help/src/main/javahelp/contents/ui/tabs/spider.html
@@ -4,7 +4,7 @@
 <META HTTP-EQUIV="Content-Type" CONTENT="text/html; charset=utf-8">
 <title>Spider tab</title>
 </head>
-<body bgcolor="#ffffff">
+<body>
 	<h1>Spider tab</h1>
 	<p>
 		The Spider tab shows you the set of unique URIs found by the <a

--- a/addOns/help/src/main/javahelp/contents/ui/tlmenu/analysis.html
+++ b/addOns/help/src/main/javahelp/contents/ui/tlmenu/analysis.html
@@ -6,7 +6,7 @@
 The Analyse menu
 </TITLE>
 </HEAD>
-<BODY BGCOLOR="#ffffff">
+<BODY>
 <H1>The Analyse menu</H1>
 This menu handles the scan policy.
 <p>

--- a/addOns/help/src/main/javahelp/contents/ui/tlmenu/edit.html
+++ b/addOns/help/src/main/javahelp/contents/ui/tlmenu/edit.html
@@ -6,7 +6,7 @@
 The Edit menu
 </TITLE>
 </HEAD>
-<BODY BGCOLOR="#ffffff">
+<BODY>
 <H1>The Edit menu</H1>
 This menu handles finding strings in specific tabs, searching for strings across all 
 requests and responses, changing ZAP's mode, and managing forced user mode.

--- a/addOns/help/src/main/javahelp/contents/ui/tlmenu/file.html
+++ b/addOns/help/src/main/javahelp/contents/ui/tlmenu/file.html
@@ -6,7 +6,7 @@
 The File menu
 </TITLE>
 </HEAD>
-<BODY BGCOLOR="#ffffff">
+<BODY>
 <H1>The File menu</H1>
 This menu handles the current session. By default the following menu items will be present:<br/>
 

--- a/addOns/help/src/main/javahelp/contents/ui/tlmenu/help.html
+++ b/addOns/help/src/main/javahelp/contents/ui/tlmenu/help.html
@@ -6,7 +6,7 @@
 The Help menu
 </TITLE>
 </HEAD>
-<BODY BGCOLOR="#ffffff">
+<BODY>
 <H1>The Help menu</H1>
 This menu gives access to the 'about' dialog and this help file.
 

--- a/addOns/help/src/main/javahelp/contents/ui/tlmenu/import.html
+++ b/addOns/help/src/main/javahelp/contents/ui/tlmenu/import.html
@@ -6,7 +6,7 @@
 The Import menu
 </TITLE>
 </HEAD>
-<BODY BGCOLOR="#ffffff">
+<BODY>
 <H1>The Import menu</H1>
 This gives access to menus that allow to import data into ZAP.
 

--- a/addOns/help/src/main/javahelp/contents/ui/tlmenu/online.html
+++ b/addOns/help/src/main/javahelp/contents/ui/tlmenu/online.html
@@ -6,7 +6,7 @@
 The Online menu
 </TITLE>
 </HEAD>
-<BODY BGCOLOR="#ffffff">
+<BODY>
 <H1>The Online menu</H1>
 This menu gives access to a set of online resources.
 

--- a/addOns/help/src/main/javahelp/contents/ui/tlmenu/report.html
+++ b/addOns/help/src/main/javahelp/contents/ui/tlmenu/report.html
@@ -6,7 +6,7 @@
 The Report menu
 </TITLE>
 </HEAD>
-<BODY BGCOLOR="#ffffff">
+<BODY>
 <H1>The Report menu</H1>
 This menu handles the reports.
 

--- a/addOns/help/src/main/javahelp/contents/ui/tlmenu/tlmenu.html
+++ b/addOns/help/src/main/javahelp/contents/ui/tlmenu/tlmenu.html
@@ -6,7 +6,7 @@
 Top Level Menu
 </TITLE>
 </HEAD>
-<BODY BGCOLOR="#ffffff">
+<BODY>
 <H1>Top Level Menu</H1>
 By default the following top level menu items will be present:<br/>
 

--- a/addOns/help/src/main/javahelp/contents/ui/tlmenu/tools.html
+++ b/addOns/help/src/main/javahelp/contents/ui/tlmenu/tools.html
@@ -6,7 +6,7 @@
 The Tools menu
 </TITLE>
 </HEAD>
-<BODY BGCOLOR="#ffffff">
+<BODY>
 <H1>The Tools menu</H1>
 This menu handles the tools and general options.
 

--- a/addOns/help/src/main/javahelp/contents/ui/tlmenu/view.html
+++ b/addOns/help/src/main/javahelp/contents/ui/tlmenu/view.html
@@ -6,7 +6,7 @@
 The View menu
 </TITLE>
 </HEAD>
-<BODY BGCOLOR="#ffffff">
+<BODY>
 <H1>The View menu</H1>
 This menu handles the display options.
 

--- a/addOns/help/src/main/javahelp/contents/ui/tltoolbar.html
+++ b/addOns/help/src/main/javahelp/contents/ui/tltoolbar.html
@@ -6,7 +6,7 @@
 Top Level Toolbar
 </TITLE>
 </HEAD>
-<BODY BGCOLOR="#ffffff">
+<BODY>
 <H1>Top Level Toolbar</H1>
 <p>
 This toolbar provides a set of controls for commonly used functionality.

--- a/addOns/help/src/main/javahelp/contents/ui/views.html
+++ b/addOns/help/src/main/javahelp/contents/ui/views.html
@@ -6,7 +6,7 @@
 Views
 </TITLE>
 </HEAD>
-<BODY BGCOLOR="#ffffff">
+<BODY>
 <H1>Views</H1>
 <p>
 ZAP provides a set of plugable views which allows you to display the requests and responses in different ways.<br/>


### PR DESCRIPTION
Let the UI set the colour of the background, no help page requires the
background to be white (there's just one place where the text colour is
changed, to red).

Part of zaproxy/zaproxy#5542.