### PR TITLE
Add note about exe and command line args

### DIFF
--- a/addOns/help/src/main/javahelp/contents/cmdline.html
+++ b/addOns/help/src/main/javahelp/contents/cmdline.html
@@ -12,6 +12,7 @@ Command Line
 To run ZAP via the command line, you will need to locate the ZAP startup script.<br/>
 <strong>Windows:</strong><br/>
 <pre>C:\Program Files (x86)\OWASP\Zed Attack Proxy\zap.bat</pre>
+<strong>Note:</strong> The command line options are not used by the executable (<code>zap.exe</code>) only the bat file.<br/><br/>
 <strong>Mac:</strong><br/>
 <pre>/Applications/OWASP\ ZAP.app/Contents/Java/zap.sh</pre>
 <strong>Linux:</strong><br/>


### PR DESCRIPTION
Be explicit that the executable will not use the command line arguments.

---
From OWASP ZAP User Group: https://groups.google.com/d/topic/zaproxy-users/ps1Esc6YX2o/discussion