### PR TITLE
Credit and website link tweaks

### DIFF
--- a/addOns/help/src/main/javahelp/contents/credits.html
+++ b/addOns/help/src/main/javahelp/contents/credits.html
@@ -13,11 +13,9 @@ Credits
 People who have made significant enhancements to the latest releases.<br>
 For more details of code contributions see: <a href="https://www.openhub.net/p/zaproxy/contributors">https://www.openhub.net/p/zaproxy/contributors</a>
 <table>
-<tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td>Simon Bennetts (<a href="https://twitter.com/psiinon">@psiinon</a>) - Mozilla</td></tr>
+<tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td>Simon Bennetts (<a href="https://twitter.com/psiinon">@psiinon</a>) - StackHawk</td></tr>
 <tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td>thc202</td></tr>
 <tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td>Rick Mitchell (Kingthorin)</td></tr>
-<tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td>David Scrobonia (<a href="https://twitter.com/david_scrobonia">@david_scrobonia</a>)</td></tr>
-<tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td>Sherif Mansour</td></tr>
 <tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td>Nirojan Selvanathan (<a href="https://twitter.com/sshniro">@sshniro</a>)</td></tr>
 </table>
 
@@ -74,7 +72,7 @@ People who have made contributions to ZAP over the years, in alphabetical order:
 <tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td>Niranjan Hegde (nhegde610)</td></tr>
 <tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td>Omer Levi Hevroni</td></tr>
 <tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td>Stevie Holdway</td></tr>
-<tr><td>&npsp;&nbsp;&nbsp;&nbsp;</td><td>Jannik Hollenbach (<a href="https://twitter.com/j12934">@j12934</a>)</td></tr>
+<tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td>Jannik Hollenbach (<a href="https://twitter.com/j12934">@j12934</a>)</td></tr>
 <tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td>Oleksandr Horokh</td></tr>
 
 <tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td>Daiki Ichinose (<a href="https://twitter.com/mahoyaya">@mahoyaya</a>)</td></tr>
@@ -106,6 +104,7 @@ People who have made contributions to ZAP over the years, in alphabetical order:
 <tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td>Dejan Lukan (eleanor)</td></tr>
 
 <tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td>Pulasthi Mahawithana</td></tr>
+<tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td>Sherif Mansour</td></tr>
 <tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td>Yuji Matsunaga - CyberDefense</td></tr> 	
 <tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td>Justin Matte (JFM9)</td></tr>
 <tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td>Rory McCune - NCC Group PLC</td></tr>
@@ -150,6 +149,7 @@ People who have made contributions to ZAP over the years, in alphabetical order:
 <tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td>Dominic Scheirlinck (<a href="https://twitter.com/dominics">@dominics</a>)</td></tr>
 <tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td>Peter Schuler</td></tr>
 <tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td>Rafał Ścipień</td></tr>
+<tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td>David Scrobonia (<a href="https://twitter.com/david_scrobonia">@david_scrobonia</a>)</td></tr>
 <tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td>Justin Searle</td></tr>
 <tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td>Alessandro Secco</td></tr>
 <tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td>Bill Sempf - Columbus OWASP</td></tr>

--- a/addOns/help/src/main/javahelp/contents/intro.html
+++ b/addOns/help/src/main/javahelp/contents/intro.html
@@ -21,6 +21,8 @@ developers and functional testers who are new to penetration testing.
 <p>
 ZAP provides automated scanners as well as a set of tools that allow you to find security vulnerabilities manually.
 <p>
+ZAP can also be run in a completely automated way - see the <a href="https://www.zaproxy.org/">ZAP website</a> for more details.
+<p>
 If you are new to ZAP then its recommended that you look at the <a href="start/start.html">Getting Started</a> section.
 <p>
 ZAP is a fork of the open source variant of the <a href="paros.html">Paros Proxy</a>.
@@ -40,10 +42,13 @@ start using ZAP</td></tr>
 <a href="cmdline.html">Command Line</a></td><td>for the command line options available</td></tr>
 <tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td>
 <a href="releases/releases.html">Releases</a></td><td>for details of the changes made in ZAP releases</td></tr>
+<tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td>
+<a href="credits.html">Credits</a></td><td>for the list of people who have contributed to ZAP</td></tr>
 </table>
 
 <H2>External links</H2>
 <table>
+<tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td><a href="https://www.zaproxy.org/">Main ZAP website</a></td></tr>
 <tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td><a href="https://owasp.org/www-project-zap/">OWASP ZAP homepage</a></td></tr>
 <tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td><a href="https://en.wikipedia.org/wiki/Proxy_server">Wikipedia entry for proxies</a></td></tr>
 </table>


### PR DESCRIPTION
Updated core team.
Added note about automation and links to the main website.
Will fix https://github.com/zaproxy/zaproxy-website/issues/138 when
deployed.

Signed-off-by: Simon Bennetts <psiinon@gmail.com>