### PR TITLE
Remove Aspect Security

### DIFF
--- a/addOns/help/src/main/javahelp/contents/credits.html
+++ b/addOns/help/src/main/javahelp/contents/credits.html
@@ -38,7 +38,7 @@ People who have made contributions to ZAP over the years, in alphabetical order:
 
 <tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td>Ahmed Bahajjaj (<a href="https://github.com/madanalogy">@madanalogy</a>)</td></tr>
 <tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td>Florent Baillais (<a href="https://twitter.com/flocurity">@flocurity</a>)</td></tr>
-<tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td>Jay Ball - Aspect Security</td></tr>
+<tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td>Jay Ball</td></tr>
 <tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td>Adrien de Beaupre</td></tr>
 <tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td>Alla Bezroutchko - Gremwell</td></tr>
 <tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td>Artemy Bogdanov (<a href="https://twitter.com/Abr1k0s">@Abr1k0s</a>)</td></tr>
@@ -177,7 +177,7 @@ People who have made contributions to ZAP over the years, in alphabetical order:
 
 <tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td>Kevin Wall</td></tr>
 <tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td>Martin Walton - Laterooms.com</td></tr>
-<tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td>Dave Wichers - Aspect Security</td></tr>
+<tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td>Dave Wichers</td></tr>
 
 <tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td>Joset Zamora (<a href="https://twitter.com/setzamora">@setzamora</a>)</td></tr>
 <tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td>Alexander Zapasnik</td></tr>


### PR DESCRIPTION
As it no longer exists - change suggested by Dave Wichers.

Signed-off-by: Simon Bennetts <psiinon@gmail.com>