### PR TITLE
Add video links

### DIFF
--- a/addOns/help/src/main/javahelp/contents/addons/introduction.html
+++ b/addOns/help/src/main/javahelp/contents/addons/introduction.html
@@ -13,6 +13,7 @@ Add-ons
 
 If you are reading this page via a ZAP help file (as opposed to reading it online) then any
 help pages associated with the add-ons you have installed will be available under this section. 
-
+<p>
+You can install additional add-ons via the <a href="../start/features/marketplace.html">Marketplace</a>.
 </BODY>
 </HTML>

--- a/addOns/help/src/main/javahelp/contents/intro.html
+++ b/addOns/help/src/main/javahelp/contents/intro.html
@@ -53,5 +53,11 @@ start using ZAP</td></tr>
 <tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td><a href="https://en.wikipedia.org/wiki/Proxy_server">Wikipedia entry for proxies</a></td></tr>
 </table>
 
+<H2>Official Videos</H2>
+<table>
+<tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td>
+<td><a href="https://www.zaproxy.org/videos/">https://www.zaproxy.org/videos/</a> An ever growing collection of ZAP videos</td></tr>
+</table>
+
 </BODY>
 </HTML>

--- a/addOns/help/src/main/javahelp/contents/start/features/ascan.html
+++ b/addOns/help/src/main/javahelp/contents/start/features/ascan.html
@@ -57,5 +57,11 @@ The rules that run are configured via <a href="scanpolicy.html">Scan Policies</a
 <a href="../checks.html">Scanner Rules</a></td><td>supported by default</td></tr>
 </table>
 
+<H2>Official Videos</H2>
+<table>
+<tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td>
+<td><a href="https://play.sonatype.com/watch/ZcEfSihgQSzuthJi4qEeW3">ZAP In Ten: Active Scanning</a> (9:47)</td></tr>
+</table>
+
 </BODY>
 </HTML>

--- a/addOns/help/src/main/javahelp/contents/start/features/authentication.html
+++ b/addOns/help/src/main/javahelp/contents/start/features/authentication.html
@@ -119,5 +119,15 @@
 
 	</table>
 
+<H2>Official Videos</H2>
+<table>
+<tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td>
+<td><a href="https://play.sonatype.com/watch/ttqKANDzJCAdBUkPrsz6Td">ZAP In Ten: Authentication: Basic and Digest</a> (9:57)</td></tr>
+<tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td>
+<td><a href="https://play.sonatype.com/watch/B1vhaLSUsme7eA5hU8WeGB">ZAP In Ten: Authentication: Form Based</a> (12:59)</td></tr>
+<tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td>
+<td><a href="https://www.zaproxy.org/addo-auth-workshop/">ZAP In Ten: ADDO Automation and Authentication Workshop</a> (8 videos)</td></tr>
+</table>
+
 </body>
 </html>

--- a/addOns/help/src/main/javahelp/contents/start/features/features.html
+++ b/addOns/help/src/main/javahelp/contents/start/features/features.html
@@ -23,6 +23,7 @@ ZAP provides the following features:
 <tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td><a href="ddc.html">Data Driven Content</a></td><td></td></tr>
 <tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td><a href="httpsessions.html">HTTP Sessions</a></td><td></td></tr>
 <tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td><a href="intercept.html">Manipulator-in-the-middle Proxy</a></td><td></td></tr>
+<tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td><a href="marketplace.html">Marketplace</a></td><td></td></tr>
 <tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td><a href="modes.html">Modes</a></td><td></td></tr>
 <tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td><a href="notes.html">Notes</a></td><td></td></tr>
 <tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td><a href="pscan.html">Passive Scan</a></td><td></td></tr>

--- a/addOns/help/src/main/javahelp/contents/start/features/marketplace.html
+++ b/addOns/help/src/main/javahelp/contents/start/features/marketplace.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 3.2 Final//EN">
+<HTML>
+<HEAD>
+<META HTTP-EQUIV="Content-Type" CONTENT="text/html; charset=utf-8">
+<TITLE>
+Marketplace
+</TITLE>
+</HEAD>
+<BODY>
+<H1>Marketplace</H1>
+<p>
+ZAP Marketplace contains ZAP add-ons which have been written by the ZAP team and the community. The add-ons help to extend the functionalities of ZAP.
+You can browse and download add-ons from within ZAP by clicking on the 
+<img src="../../images/fugue/block.png" align="bottom" width="16" height="16" /> 'Manage Add-ons' button in the toolbar and then selecting the Marketplace tab.
+<p>
+All of the add-ons on the ZAP Marketplace are, of course, free and open source.
+
+<H2>See also</H2>
+<table>
+<tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td>
+<a href="../../ui/overview.html">UI Overview</a></td><td>for an overview of the user interface</td></tr>
+<tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td>
+<a href="features.html">Features</a></td><td>provided by ZAP</td></tr>
+</table>
+
+<H2>Official Videos</H2>
+<table>
+<tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td>
+<td><a href="https://play.sonatype.com/watch/u5Wv6KsoozBefCuEmrFDzC">ZAP In Ten: The ZAP Marketplace</a> (9:47)</td></tr>
+</table>
+
+</BODY>
+</HTML>

--- a/addOns/help/src/main/javahelp/contents/start/features/pscan.html
+++ b/addOns/help/src/main/javahelp/contents/start/features/pscan.html
@@ -42,5 +42,11 @@ The alerts raised by passive scanners can be configured using the
 <a href="../checks.html">Scanner Rules</a></td><td>supported by default</td></tr>
 </table>
 
+<H2>Official Videos</H2>
+<table>
+<tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td>
+<td><a href="https://play.sonatype.com/watch/vDWpoYjHi7fSLYFDQPWgMF">ZAP In Ten: Passive Scanning</a> (10:27)</td></tr>
+</table>
+
 </BODY>
 </HTML>

--- a/addOns/help/src/main/javahelp/contents/start/features/scripts.html
+++ b/addOns/help/src/main/javahelp/contents/start/features/scripts.html
@@ -57,5 +57,19 @@ For more details on how to run ZAP scripts see the Script Console add-on help pa
 <tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td><a href="https://github.com/zaproxy/community-scripts">ZAP Community Scripts repo</a></td></tr>
 </table>
 
+<H2>Official Videos</H2>
+<table>
+<tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td>
+<td><a href="https://play.sonatype.com/watch/7gR4qYzUZ686wEDMBfxGdf">ZAP In Ten: ZAP Scripting - An Introduction</a> (9:33)</td></tr>
+<tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td>
+<td><a href="https://play.sonatype.com/watch/JzX1YkJqdk7BYTMHikh433">ZAP In Ten: ZAP Scripting - Targeted Scripts</a> (10:01)</td></tr>
+<tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td>
+<td><a href="https://play.sonatype.com/watch/4no8EY1iB8RdnQLPFpYi2a">ZAP In Ten: ZAP Scripting - Proxy and HttpSender Scripts</a> (10:14)</td></tr>
+<tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td>
+<td><a href="https://play.sonatype.com/watch/HfENJ3GJB3zbD6sMscDrjD">ZAP In Ten: ZAP Scripting - Passive Scan Scripts</a> (11:55)</td></tr>
+<tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td>
+<td><a href="https://play.sonatype.com/watch/aEwqErXFMTYdDDQbTgnJeA">ZAP In Ten: ZAP Scripting - Active Scan Scripts</a> (11:38)</td></tr>
+</table>
+
 </BODY>
 </HTML>

--- a/addOns/help/src/main/javahelp/contents/start/features/spider.html
+++ b/addOns/help/src/main/javahelp/contents/start/features/spider.html
@@ -94,5 +94,13 @@
 		</tr>
 	</table>
 
+<H2>Official Videos</H2>
+<table>
+<tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td>
+<td><a href="https://play.sonatype.com/watch/rLq2nvgbuGwVn2BX9gA8r2">ZAP In Ten: Explore Your Applications</a></td><td>(10:36)</td></tr>
+<tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td>
+<td><a href="https://youtu.be/mz2nhYpU-sw">ZAP Deep Dive: Exploring Applications: Standard Spider</a> (34:35)</td></tr>
+</table>
+
 </body>
 </html>

--- a/addOns/help/src/main/javahelp/contents/ui/overview.html
+++ b/addOns/help/src/main/javahelp/contents/ui/overview.html
@@ -83,5 +83,13 @@ start using ZAP</td></tr>
 <a href="../intro.html">Introduction</a></td><td>the introduction to ZAP</td></tr>
 </table>
 
+<H2>Official Videos</H2>
+<table>
+<tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td>
+<td><a href="https://play.sonatype.com/watch/p35FK8Cri5A3EF3RBGoMAr">ZAP In Ten: The Desktop Interface</a> (10:05)</td></tr>
+<tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td>
+<td><a href="https://youtu.be/-kbY4k8eSd0">ZAP Deep Dive: The Desktop Interface</a> (31:53)</td></tr>
+</table>
+
 </BODY>
 </HTML>

--- a/addOns/help/src/main/javahelp/index.xml
+++ b/addOns/help/src/main/javahelp/index.xml
@@ -45,6 +45,7 @@
     <indexitem text="introduction" target="zap.intro" />
     <indexitem text="manage tabs dialog" target="ui.dialogs.managetags" />
     <indexitem text="manual request dialog" target="ui.dialogs.manreq" />
+    <indexitem text="marketplace" target="start.features.marketplace" />
     <indexitem text="modes" target="start.features.modes" />
     <indexitem text="notes" target="start.features.notes" />
     <indexitem text="options dialog" target="ui.dialogs.options" />

--- a/addOns/help/src/main/javahelp/toc.xml
+++ b/addOns/help/src/main/javahelp/toc.xml
@@ -31,6 +31,7 @@
          <tocitem text="Globally Excluded URLs" target="start.features.globalexcludeurl"/>
          <tocitem text="HTTP Sessions" target="start.features.httpsessions"/>
          <tocitem text="Manipulator-in-the-middle Proxy" target="start.features.intercept"/>
+         <tocitem text="Marketplace" target="start.features.marketplace"/>
          <tocitem text="Modes" target="start.features.modes"/>
          <tocitem text="Notes" target="start.features.notes"/>
          <tocitem text="Passive Scan" target="start.features.pscan"/>

--- a/commonFiles/src/main/resources/map.jhm
+++ b/commonFiles/src/main/resources/map.jhm
@@ -26,6 +26,7 @@
         <mapID target="start.features.globalexcludeurl" url="contents/start/features/globalexcludeurl.html" />
         <mapID target="start.features.httpsessions" url="contents/start/features/httpsessions.html" />
         <mapID target="start.features.intercept" url="contents/start/features/intercept.html" />
+        <mapID target="start.features.marketplace" url="contents/start/features/marketplace.html" />
         <mapID target="start.features.modes" url="contents/start/features/modes.html" />
         <mapID target="start.features.notes" url="contents/start/features/notes.html" />
         <mapID target="start.features.pscan" url="contents/start/features/pscan.html" />


### PR DESCRIPTION
Example screenshot:
<img width="1004" alt="Screenshot 2020-11-18 at 10 44 43" src="https://user-images.githubusercontent.com/1081115/99520731-62389380-298b-11eb-8b7a-6a7feed9ed2b.png">

Tried adding a video icon but it didnt look quite right, so dropped it.
Was also thinking of adding a link off the first page to https://www.zaproxy.org/videos/

Any feedback?

Signed-off-by: Simon Bennetts <psiinon@gmail.com>