### PR TITLE
Upload files to Crowdin on release and manually

### DIFF
--- a/.github/workflows/crowdin-upload-files.yml
+++ b/.github/workflows/crowdin-upload-files.yml
@@ -1,0 +1,19 @@
+name: Crowdin Upload Files
+
+on:
+  workflow_dispatch:
+
+jobs:
+  upload:
+    name: Upload Files
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Setup Java
+      uses: actions/setup-java@v1
+      with:
+        java-version: 8
+    - name: Upload Files
+      env:
+        CROWDIN_AUTH_TOKEN: ${{ secrets.ZAPBOT_CROWDIN_TOKEN }}
+      run: ./gradlew crowdinUploadSourceFiles

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 .gradle
 /build
 /buildSrc/build
+/addOns/build
 /addOns/*/build
 /commonFiles/build
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -8,3 +8,12 @@ The following steps should be followed to release the add-ons:
 
 After merging the pull request the [Release Add-on](https://github.com/zaproxy/zap-core-help/actions/workflows/release-add-on.yml) workflow
 will create the tag(s), create the release(s), trigger the update of the marketplace, and create a pull request preparing the next development iterations.
+
+## Localized Resources
+
+The resources that require localization (e.g. help pages) are uploaded to the OWASP ZAP project in [Crowdin](https://crowdin.com/) when the main add-on is released,
+if required (for pre-translation) the resources can be uploaded manually at anytime by running the workflow
+[Crowdin Upload Files](https://github.com/zaproxy/zap-core-help/actions/workflows/crowdin-upload-files.yml).
+
+The resulting localized resources are added/updated in the repository periodically (through a workflow in the
+[zap-admin repository](https://github.com/zaproxy/zap-admin/)).

--- a/addOns/addOns.gradle.kts
+++ b/addOns/addOns.gradle.kts
@@ -13,13 +13,24 @@ import org.zaproxy.gradle.addon.misc.ConvertMarkdownToHtml
 
 plugins {
     eclipse
-    id("org.zaproxy.add-on") version "0.6.0" apply false
+    id("org.zaproxy.add-on") version "0.7.0" apply false
+    id("org.zaproxy.crowdin") version "0.1.0"
 }
 
 eclipse {
     project {
         // Prevent collision with zap-extensions' addOns project.
         name = "addOnsHelp"
+    }
+}
+
+crowdin {
+    credentials {
+        token.set(System.getenv("CROWDIN_AUTH_TOKEN"))
+    }
+
+    configuration {
+        file.set(file("$rootDir/gradle/crowdin.yml"))
     }
 }
 
@@ -118,6 +129,9 @@ subprojects {
 
             dependsOn(handleRelease)
             dependsOn(createPullRequestNextDevIter)
+            if (project.zapAddOn.addOnId.get() == "help") {
+                dependsOn(":addOns:crowdinUploadSourceFiles")
+            }
         }
 
         val addOnRelease = AddOnRelease.from(project)

--- a/gradle/crowdin.yml
+++ b/gradle/crowdin.yml
@@ -1,0 +1,33 @@
+projects:
+  - id: 32705
+    sources:
+      - dir: "help/src/main/javahelp"
+        outputDir: ""
+        crowdinPath:
+          dir: "/core"
+          filename: "%file_pathname%"
+        exportPattern:
+          dir: "/zaproxy/core"
+          filename: "help_%locale_with_underscore%/src/main/javahelp/%file_pathname%"
+        includes:
+          - pattern: "contents/***.html"
+          - pattern: "helpset.hs"
+            crowdinPathFilename: "%file_name%.xml"
+            exportPatternFilename: "help_%locale_with_underscore%/src/main/javahelp/%file_name%_%locale_with_underscore%%file_extension%"
+            translatableElements:
+              - "/helpset/title"
+              - "/helpset/presentation/title"
+              - "/helpset/view/label"
+          - pattern: "toc.xml"
+            translatableElements:
+              # Crowdin doesn't support descendant axis
+              # "/toc/descendant::tocitem[@text]"
+              # Define manually some:
+              - "/toc/tocitem[@text]"
+              - "/toc/tocitem/tocitem[@text]"
+              - "/toc/tocitem/tocitem/tocitem[@text]"
+              - "/toc/tocitem/tocitem/tocitem/tocitem[@text]"
+              - "/toc/tocitem/tocitem/tocitem/tocitem/tocitem[@text]"
+          - pattern: "index.xml"
+            translatableElements:
+              - "/index/indexitem[@text]"


### PR DESCRIPTION
Change release process to upload the files to Crowdin as part of the
(main) add-on release.
Add workflow to trigger the upload of the files, to allow to start to
translate the files before the actual release.