### PR TITLE
Include zapbot Crowdin auth token for releases

### DIFF
--- a/.github/workflows/release-add-on.yml
+++ b/.github/workflows/release-add-on.yml
@@ -25,4 +25,5 @@ jobs:
     - name: Build and Release Add-On
       env:
         ZAPBOT_TOKEN: ${{ secrets.ZAPBOT_TOKEN }}
+        CROWDIN_AUTH_TOKEN: ${{ secrets.ZAPBOT_CROWDIN_TOKEN }}
       run: ./gradlew :addOns:releaseAddOn


### PR DESCRIPTION
The auth token is required to upload the source files to Crowdin when
the (main) add-on is released.