### PR TITLE
Fix release of add-ons and other tweaks

### DIFF
--- a/addOns/addOns.gradle.kts
+++ b/addOns/addOns.gradle.kts
@@ -124,12 +124,13 @@ subprojects {
             tagMessage.set(message)
             title.set(message)
         }
+        val zapAddOnExt = project.zapAddOn
         releaseAddOn {
             dependsOn(createReleaseAddOn)
 
             dependsOn(handleRelease)
             dependsOn(createPullRequestNextDevIter)
-            if (project.zapAddOn.addOnId.get() == "help") {
+            if (zapAddOnExt.addOnId.get() == "help") {
                 dependsOn(":addOns:crowdinUploadSourceFiles")
             }
         }

--- a/addOns/help/CHANGELOG.md
+++ b/addOns/help/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [12] - 2021-10-06
 ### Changed
+- Updated for 2.11.0.
 - Remove extra column in a videos table.
 - Update link to zaproxy and community-scripts repo.
 

--- a/addOns/help/gradle.properties
+++ b/addOns/help/gradle.properties
@@ -1,2 +1,2 @@
 version=12
-release=true
+release=false


### PR DESCRIPTION
Keep a reference to the project's add-on extension to reference in the
release task.
Reset the release state of the help add-on, to trigger later.
Update the changelog to mention the update for 2.11.