### PR TITLE
Update add-ons to ZAP 2.11 and release main

### DIFF
--- a/addOns/addOns.gradle.kts
+++ b/addOns/addOns.gradle.kts
@@ -83,7 +83,7 @@ subprojects {
     }
 
     zapAddOn {
-        zapVersion.set("2.9.0")
+        zapVersion.set("2.11.0")
 
         releaseLink.set(project.provider { "https://github.com/zaproxy/zap-core-help/releases/${zapAddOn.addOnId.get()}-v@CURRENT_VERSION@" })
 
@@ -95,6 +95,7 @@ subprojects {
     }
 
     dependencies {
+        "zap"("org.zaproxy:zap:2.11.0-20210929.165234-4")
         "implementation"(project(":commonFiles"))
     }
 

--- a/addOns/help/gradle.properties
+++ b/addOns/help/gradle.properties
@@ -1,2 +1,2 @@
 version=12
-release=false
+release=true

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,6 +7,9 @@ allprojects {
 
     repositories {
         mavenCentral()
+        maven {
+            url = uri("https://oss.sonatype.org/content/repositories/snapshots/")
+        }
     }
 
     spotless {


### PR DESCRIPTION
Set the add-ons to use 2.11 (SNAPSHOT).
Change release state to trigger the release of help add-on.