### PR TITLE
Stop using ZAP snapshot

### DIFF
--- a/addOns/addOns.gradle.kts
+++ b/addOns/addOns.gradle.kts
@@ -95,7 +95,6 @@ subprojects {
     }
 
     dependencies {
-        "zap"("org.zaproxy:zap:2.11.0-20210929.165234-4")
         "implementation"(project(":commonFiles"))
     }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,9 +7,6 @@ allprojects {
 
     repositories {
         mavenCentral()
-        maven {
-            url = uri("https://oss.sonatype.org/content/repositories/snapshots/")
-        }
     }
 
     spotless {


### PR DESCRIPTION
Use main release, already available.