### PR TITLE
Add release notes for 2.11.1 and prepare release

### DIFF
--- a/addOns/help/CHANGELOG.md
+++ b/addOns/help/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this add-on will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [13] - 2021-12-10
+### Changed
+- Updated for 2.11.1.
+
 ## [12] - 2021-10-06
 ### Changed
 - Updated for 2.11.0.
@@ -50,6 +54,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - First version.
 
+[13]: https://github.com/zaproxy/zap-core-help/releases/help-v13
 [12]: https://github.com/zaproxy/zap-core-help/releases/help-v12
 [11]: https://github.com/zaproxy/zap-core-help/releases/help-v11
 [10]: https://github.com/zaproxy/zap-core-help/releases/help-v10

--- a/addOns/help/gradle.properties
+++ b/addOns/help/gradle.properties
@@ -1,2 +1,2 @@
-version=12
+version=13
 release=true

--- a/addOns/help/src/main/javahelp/contents/releases/2.11.1.html
+++ b/addOns/help/src/main/javahelp/contents/releases/2.11.1.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 3.2 Final//EN">
+<HTML>
+<HEAD>
+<META HTTP-EQUIV="Content-Type" CONTENT="text/html; charset=utf-8">
+<TITLE>
+  Release 2.11.1
+</TITLE>
+</HEAD>
+<BODY>
+<H1>Release 2.11.1</H1>
+<p>
+This release includes an important security fix - users are urged to upgrade asap.
+For more details refer to the blog post <a href="https://www.zaproxy.org/blog/2021-12-10-zap-and-log4shell/">ZAP and Log4Shell</a>.
+</p>
+<H2>Changes in Bundled Libraries</H2>
+The following library was updated:
+
+<ul>
+  <li>Log4j 2, 2.14.1 → 2.15.0</li>
+</ul>
+
+
+<H2>See also</H2>
+<table>
+<tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td><a href="../intro.html">Introduction</a></td><td>the introduction to ZAP</td></tr>
+<tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td><a href="releases.html">Releases</a></td><td>the full set of releases</td></tr>
+<tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td><a href="../credits.html">Credits</a></td><td>the people and groups who have made this release possible</td></tr>
+</table>
+</BODY>
+</HTML>

--- a/addOns/help/src/main/javahelp/contents/releases/releases.html
+++ b/addOns/help/src/main/javahelp/contents/releases/releases.html
@@ -11,6 +11,7 @@ Releases
 <p>
 The following releases have been made:
 <table>
+<tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td><a href="2.11.1.html">2.11.1</a></td><td>includes an important security fix - users are urged to upgrade asap</td></tr>
 <tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td><a href="2.11.0.html">2.11.0</a></td><td>OWASP 20th anniversary bug fix and enhancement release</td></tr>
 <tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td><a href="2.10.0.html">2.10.0</a></td><td>10 year anniversary bug fix and enhancement release</td></tr>
 <tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td><a href="2.9.0.html">2.9.0</a></td><td>bug fix and enhancement release</td></tr>

--- a/addOns/help/src/main/javahelp/index.xml
+++ b/addOns/help/src/main/javahelp/index.xml
@@ -84,6 +84,7 @@
     <indexitem text="release 2.9.0" target="zap.releases.2.9.0" />
     <indexitem text="release 2.10.0" target="zap.releases.2.10.0" />
     <indexitem text="release 2.11.0" target="zap.releases.2.11.0" />
+    <indexitem text="release 2.11.1" target="zap.releases.2.11.1" />
     <indexitem text="releases" target="zap.releases" />
     <indexitem text="request tab" target="ui.tabs.request" />
     <indexitem text="response tab" target="ui.tabs.response" />

--- a/addOns/help/src/main/javahelp/toc.xml
+++ b/addOns/help/src/main/javahelp/toc.xml
@@ -130,6 +130,7 @@
    <tocitem text="Add-ons" target="addons.introduction" tocid="addons" image="addons.icon" />
    
    <tocitem text="Releases" target="zap.releases">
+      <tocitem text="2.11.1" target="zap.releases.2.11.1"/>
       <tocitem text="2.11.0" target="zap.releases.2.11.0"/>
       <tocitem text="2.10.0" target="zap.releases.2.10.0"/>
       <tocitem text="2.9.0" target="zap.releases.2.9.0"/>


### PR DESCRIPTION
Add the releases notes for the new ZAP version.
Update changelog and version for release.