### PR TITLE
Update 2.11.1 release notes and prepare release

### DIFF
--- a/addOns/help/CHANGELOG.md
+++ b/addOns/help/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this add-on will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [14] - 2021-12-10
+### Changed
+- Updated 2.11.1 release notes.
+
 ## [13] - 2021-12-10
 ### Changed
 - Updated for 2.11.1.
@@ -54,6 +58,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - First version.
 
+[14]: https://github.com/zaproxy/zap-core-help/releases/help-v14
 [13]: https://github.com/zaproxy/zap-core-help/releases/help-v13
 [12]: https://github.com/zaproxy/zap-core-help/releases/help-v12
 [11]: https://github.com/zaproxy/zap-core-help/releases/help-v11

--- a/addOns/help/gradle.properties
+++ b/addOns/help/gradle.properties
@@ -1,2 +1,2 @@
-version=13
+version=14
 release=true

--- a/addOns/help/src/main/javahelp/contents/releases/2.11.1.html
+++ b/addOns/help/src/main/javahelp/contents/releases/2.11.1.html
@@ -19,6 +19,8 @@ The following library was updated:
   <li>Log4j 2, 2.14.1 → 2.15.0</li>
 </ul>
 
+<H3>Updated Add-Ons</H3>
+All of the add-ons included by default have been updated since the last full release.
 
 <H2>See also</H2>
 <table>

--- a/commonFiles/src/main/resources/map.jhm
+++ b/commonFiles/src/main/resources/map.jhm
@@ -116,6 +116,7 @@
         <mapID target="zap.releases.2.9.0" url="contents/releases/2.9.0.html"/>
         <mapID target="zap.releases.2.10.0" url="contents/releases/2.10.0.html"/>
         <mapID target="zap.releases.2.11.0" url="contents/releases/2.11.0.html"/>
+        <mapID target="zap.releases.2.11.1" url="contents/releases/2.11.1.html"/>
         <mapID target="zap.credits" url="contents/credits.html" />
      	<mapID target="ui.dialogs.options.ascan" url="contents/ui/dialogs/options/ascan.html"/>
      	<mapID target="ui.dialogs.options.ascaninput" url="contents/ui/dialogs/options/ascaninput.html"/>


### PR DESCRIPTION
Mention that the add-ons are also updated.
Add missing map entry for the 2.11.1 release page.
Update changelog and version for release.