### PR TITLE
Update release notes with deprecated API endpoint

### DIFF
--- a/addOns/help/src/main/javahelp/contents/releases/2.12.0.html
+++ b/addOns/help/src/main/javahelp/contents/releases/2.12.0.html
@@ -74,6 +74,7 @@ The following endpoints have been superseded by the <a href="https://www.zaproxy
 <li>ACTION core / generateRootCA</li>
 <li>ACTION localProxies / addAdditionalProxy</li>
 <li>ACTION localProxies / removeAdditionalProxy</li>
+<li>OTHER core / proxy.pac</li>
 <li>OTHER core / rootCaCert</li>
 <li>VIEW localProxies / additionalProxies</li>
 </ul>


### PR DESCRIPTION
Add `proxy.pac` to the list of deprecated core endpoints.

Part of zaproxy/zaproxy#7240.