### PR TITLE
Remove usage of ZAP snapshot

### DIFF
--- a/addOns/addOns.gradle.kts
+++ b/addOns/addOns.gradle.kts
@@ -98,7 +98,6 @@ subprojects {
     }
 
     dependencies {
-        "zap"("org.zaproxy:zap:2.12.0-SNAPSHOT")
         "implementation"(project(":commonFiles"))
     }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,9 +7,6 @@ allprojects {
 
     repositories {
         mavenCentral()
-        maven {
-            url = uri("https://oss.sonatype.org/content/repositories/snapshots/")
-        }
     }
 
     spotless {


### PR DESCRIPTION
Use main release which is already available.