### PR TITLE
Add missing quote and correct case in UI label

### DIFF
--- a/addOns/help/src/main/javahelp/contents/start/proxies.html
+++ b/addOns/help/src/main/javahelp/contents/start/proxies.html
@@ -106,7 +106,7 @@ Ensure 'SSL Proxy' is also configured, either by selecting 'Use this proxy serve
 <H3>OS X System Proxy settings</H3>
 
 <table>
-<tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td>Select the</td><td> 'Web Proxy (HTTP)</td></tr>
+<tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td>Select the</td><td> 'Web proxy (HTTP)'</td></tr>
 <tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td>Enter in the</td><td> 'Address:' field the 'Address' you configured in the options screen</td></tr>
 <tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td>Enter in the</td><td> 'Port' field the 'Port' you configured in the options screen</td></tr>
 <tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td>Press the</td><td> Proxies Setting 'OK' button</td></tr>


### PR DESCRIPTION
Add missing quote to close the label and correct the case to match exactly what's shown in the UI.

Reported in Crowdin:
https://crowdin.com/translate/owasp-zap-help/34257/engb-es?filter=basic&value=0#q=2492728