### PR TITLE
Link to Network Command Line help page

### DIFF
--- a/addOns/help/src/main/javahelp/contents/cmdline.html
+++ b/addOns/help/src/main/javahelp/contents/cmdline.html
@@ -24,7 +24,7 @@ All options below can be passed to any of these.
 
 <H2>Options</H2>
 
-ZAP supports the following command line options:
+ZAP (core) supports the following command line options:
 
 <table>
 <tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td>-version</td><td>Reports the ZAP version</td></tr>
@@ -38,8 +38,6 @@ ZAP supports the following command line options:
 <tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td>-help</td><td>The same as -h</td></tr>
 <tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td>-newsession &lt;path&gt;</td><td>Creates a new session at the given location</td></tr>
 <tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td>-session &lt;path&gt;</td><td>Opens the given session after starting ZAP</td></tr>
-<tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td>-host &lt;host&gt;</td><td>Overrides the host used for proxying specified in the configuration file</td></tr>
-<tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td>-port &lt;port&gt;</td><td>Overrides the port used for proxying specified in the configuration file</td></tr>
 <tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td>-lowmem</td><td>Use the database instead of memory as much as possible - this is still experimental</td></tr>
 <tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td>-experimentaldb</td><td>Use the experimental generic database code, which is not surprisingly also still experimental</td></tr>
 <tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td>-nostdout</td><td>Disables the default logging through standard output</td></tr>
@@ -60,7 +58,6 @@ Relative paths to session file are resolved against the "session" directory loca
 <br/>
 Configuration keys should be specified using the dot notation based their location in the XML of the configuration file, eg:<br/>
 <pre>&lt;zap-script&gt; -config api.key=12345</pre>
-Note that add-ons can add extra command line options.
 
 <p>
 Examples:
@@ -72,6 +69,11 @@ Examples:
 			<pre>&lt;zap-script&gt; -session /full/path/to/existing/session -script /full/path/to/script.js -cmd</pre>
 		</li>
 	</ul>
+
+<H2>Add-ons</H2>
+Add-ons can add extra command line options which are described in their own help pages.
+<p>
+For the command line options that allow to configure the main local proxy, refer to the <a href="https://www.zaproxy.org/docs/desktop/addons/network/cmdline/">Network Command Line</a> help page.
 
 <H2>See also</H2>
 <table>


### PR DESCRIPTION
Remove the entries that allow to configure the main local proxy and link to Network help page instead, to avoid duplicating and to keep them up-to-date along with the code.