### PR TITLE
Add video links to contents

### DIFF
--- a/addOns/help/src/main/javahelp/contents/cmdline.html
+++ b/addOns/help/src/main/javahelp/contents/cmdline.html
@@ -83,5 +83,11 @@ For the command line options that allow to configure the main local proxy, refer
 <a href="start/features/api.html">API</a></td><td>to control ZAP programmatically</td></tr>
 </table>
 
+<H2>Official Videos</H2>
+<table>
+<tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td>
+<td><a href="https://play.vidyard.com/g97SccHH52RXnAcBYBmDGA">ADDO Automation: Automation Command Line</a> (14:03)</td></tr>
+</table>
+
 </BODY>
 </HTML>

--- a/addOns/help/src/main/javahelp/contents/start/features/addons.html
+++ b/addOns/help/src/main/javahelp/contents/start/features/addons.html
@@ -51,5 +51,11 @@ To make an add-on available to ZAP it must be in one of the following locations:
 <a href="https://www.zaproxy.org/addons/">Marketplace</a></td><td>to browse the add-ons online</td></tr>
 </table>
 
+<H2>Official Videos</H2>
+<table>
+<tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td>
+<td><a href="https://www.youtube.com/watch?v=N4OEtVCda6s">ZAPCon 2022: More Power to "ZAP" - Demystifying ZAP Add-ons</a> (40:29)</td></tr>
+</table>
+
 </BODY>
 </HTML>

--- a/addOns/help/src/main/javahelp/contents/start/features/api.html
+++ b/addOns/help/src/main/javahelp/contents/start/features/api.html
@@ -34,6 +34,8 @@ Future versions of ZAP will increase the functionality available via the APi.
 <tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td>
 <a href="../../ui/overview.html">UI Overview</a></td><td>for an overview of the user interface</td></tr>
 <tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td>
+<a href="https://www.zaproxy.org/docs/api/#introduction">API Overview</a></td><td>for an overview of the API</td></tr>
+<tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td>
 <a href="features.html">Features</a></td><td>provided by ZAP</td></tr>
 </table>
 

--- a/addOns/help/src/main/javahelp/contents/start/features/ascan.html
+++ b/addOns/help/src/main/javahelp/contents/start/features/ascan.html
@@ -61,6 +61,10 @@ The rules that run are configured via <a href="scanpolicy.html">Scan Policies</a
 <table>
 <tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td>
 <td><a href="https://play.sonatype.com/watch/ZcEfSihgQSzuthJi4qEeW3">ZAP In Ten: Active Scanning</a> (9:47)</td></tr>
+<tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td>
+<td><a href="https://play.vidyard.com/aEwqErXFMTYdDDQbTgnJeA">ZAP In Ten: Active Scan Scripts</a> (11:37)</td></tr>
+<tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td>
+<td><a href="https://www.youtube.com/watch?v=z2r4xGMQlys">Deep Dive: Active Scanning</a> (31:26)</td></tr>
 </table>
 
 </BODY>

--- a/addOns/help/src/main/javahelp/contents/start/features/pscan.html
+++ b/addOns/help/src/main/javahelp/contents/start/features/pscan.html
@@ -46,6 +46,10 @@ The alerts raised by passive scan rules can be configured using the
 <table>
 <tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td>
 <td><a href="https://play.sonatype.com/watch/vDWpoYjHi7fSLYFDQPWgMF">ZAP In Ten: Passive Scanning</a> (10:27)</td></tr>
+<tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td>
+<td><a href="https://play.vidyard.com/HfENJ3GJB3zbD6sMscDrjD">ZAP In Ten: Passive Scan Scripts</a> (11:53)</td></tr>
+<tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td>
+<td><a href="https://www.youtube.com/watch?v=Rx42kyrB0nk">Deep Dive: Passive Scanning</a> (27:35)</td></tr>
 </table>
 
 </BODY>

--- a/addOns/help/src/main/javahelp/contents/start/pentest.html
+++ b/addOns/help/src/main/javahelp/contents/start/pentest.html
@@ -53,5 +53,11 @@ https://www.owasp.org/wstg</td>
 <td> OWASP Testing Guide</td></tr>
 </table>
 
+<H2>Official Videos</H2>
+<table>
+<tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td>
+<td><a href="https://www.youtube.com/watch?v=AqZdqAK9S2g">ZAPCon 2022: Drive-By Pentesting with ZAP Scripts</a> (38:19)</td></tr>
+</table>
+
 </BODY>
 </HTML>

--- a/addOns/help/src/main/javahelp/contents/start/start.html
+++ b/addOns/help/src/main/javahelp/contents/start/start.html
@@ -60,6 +60,12 @@ The next thing to do is to start a
 <a href="checks.html">Scanner Rules</a></td><td>supported by default</td></tr>
 </table>
 
+<H2>Official Videos</H2>
+<table>
+<tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td>
+<td><a href="https://www.youtube.com/watch?v=32W_hm30dsg">ZAPCon 2022: ZAP for Everybody</a> (44:05)</td></tr>
+</table>
+
 
 
 </BODY>


### PR DESCRIPTION
Official video links are added to html files for additional references and ease of navigation. These video links are gathered from https://www.zaproxy.org/videos-list/ containing the same html format of other videos from other documentation found on www.zaproxy.org.

The only document that did not contain a video link was /addOns/help/src/main/javahelp/contents/start/features/api.html, which contains an additional link under the section 'See also' that provides a reference to the official ZAP API documentation located at https://www.zaproxy.org/docs/api/#introduction.
