### PR TITLE
Update names, links, and paths

### DIFF
--- a/addOns/help/src/main/javahelp/contents/cmdline.html
+++ b/addOns/help/src/main/javahelp/contents/cmdline.html
@@ -14,7 +14,7 @@ To run ZAP via the command line, you will need to locate the ZAP startup script.
 <pre>C:\Program Files (x86)\OWASP\Zed Attack Proxy\zap.bat</pre>
 <strong>Note:</strong> The command line options are not used by the executable (<code>zap.exe</code>) only the bat file.<br/><br/>
 <strong>Mac:</strong><br/>
-<pre>/Applications/OWASP\ ZAP.app/Contents/Java/zap.sh</pre>
+<pre>/Applications/ZAP.app/Contents/Java/zap.sh</pre>
 <strong>Linux:</strong><br/>
 <code>zap.sh</code> will be below the directory where ZAP was installed.
 <br/><br/>

--- a/addOns/help/src/main/javahelp/contents/credits.html
+++ b/addOns/help/src/main/javahelp/contents/credits.html
@@ -221,7 +221,7 @@ People who have made contributions to ZAP over the years, in alphabetical order:
 </table> 
 
 <H2>ZAP Localization</H2>
-ZAP localization is organized via <a href="https://crowdin.com/project/owasp-zap">https://crowdin.com/project/owasp-zap</a>
+ZAP localization is organized via <a href="https://crowdin.com/project/zaproxy">https://crowdin.com/project/zaproxy</a>
 <br><br>
 <table>
 <tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td>Azerbaijanian</td><td>Rashad Aliyev www.microphp.com</td></tr>

--- a/addOns/help/src/main/javahelp/contents/intro.html
+++ b/addOns/help/src/main/javahelp/contents/intro.html
@@ -3,14 +3,14 @@
 <HEAD>
 <META HTTP-EQUIV="Content-Type" CONTENT="text/html; charset=utf-8">
 <TITLE>
-The OWASP ZAP Desktop User Guide
+The ZAP Desktop User Guide
 </TITLE>
 </HEAD>
 <BODY>
 <H1>
-OWASP ZAP Desktop User Guide</H1>
+ZAP Desktop User Guide</H1>
 <p>
-Welcome to the OWASP Zed Attack Proxy (ZAP) Desktop User Guide.<br/><br/>
+Welcome to the Zed Attack Proxy (ZAP) Desktop User Guide.<br/><br/>
 This is available both as context sensitive help within ZAP and online at 
 <a href="https://www.zaproxy.org/docs/desktop/">https://www.zaproxy.org/docs/desktop/</a>
 <p>
@@ -49,7 +49,6 @@ start using ZAP</td></tr>
 <H2>External links</H2>
 <table>
 <tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td><a href="https://www.zaproxy.org/">Main ZAP website</a></td></tr>
-<tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td><a href="https://owasp.org/www-project-zap/">OWASP ZAP homepage</a></td></tr>
 <tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td><a href="https://en.wikipedia.org/wiki/Proxy_server">Wikipedia entry for proxies</a></td></tr>
 </table>
 

--- a/addOns/help/src/main/javahelp/contents/releases/2.3.0.html
+++ b/addOns/help/src/main/javahelp/contents/releases/2.3.0.html
@@ -46,7 +46,7 @@ You can now run ZAP ‘inline’ i.e. <b>without starting the ZAP UI or a daemon
 The API has been extended to support even more of the ZAP functionality.
 
 <H3>Internationalized help file</H3>
-The help file has been internationalized and is in the process of being translated into many other languages via <a href="https://crowdin.com/project/owasp-zap-help">https://crowdin.com/project/owasp-zap-help</a>. If you use ZAP in one of the many languages we support, then the help files will include all of the available translations for that language while defaulting back to English for phrases that have not yet been translated.<br>
+The help file has been internationalized and is in the process of being translated into many other languages via <a href="https://crowdin.com/project/zap-help">https://crowdin.com/project/zap-help</a>. If you use ZAP in one of the many languages we support, then the help files will include all of the available translations for that language while defaulting back to English for phrases that have not yet been translated.<br>
 Languages with a significant amount of translated help pages include:
 <ul>
 <li>Bosnian</li>
@@ -66,7 +66,7 @@ There is also an option to <b>toggle the visibility of the tab names</b> on an o
 
 <H3>More functionality moved to add-ons</H3>
 More of the core functionality has been moved into add-ons which allows us to deliver updates dynamically via the ZAP Marketplace rather than requiring new full releases.<br>
-This includes the language packs, so translations made to the ZAP UI via https://crowdin.com/project/owasp-zap can be downloaded within ZAP or even automatically installed.
+This includes the language packs, so translations made to the ZAP UI via https://crowdin.com/project/zaproxy can be downloaded within ZAP or even automatically installed.
 
 <H3>New and improved active and passive scanning rules</H3>
 Many of the release status active and passive scanning rules have been improved. There are new alpha and beta status rules and many rules have been promoted from alpha to beta and from beta to release status.

--- a/addOns/help/src/main/javahelp/contents/ui/dialogs/options/jvm.html
+++ b/addOns/help/src/main/javahelp/contents/ui/dialogs/options/jvm.html
@@ -29,8 +29,8 @@ Good values for this field could be:
 Unlike the other ZAP options these are held in the file <code>.ZAP_JVM.properties</code> in the user's default ZAP directory,
 which depends on the OS being used, for example:
 <ul>
-<li>Windows 7/8: C:\Users\<i>&lt;username&gt;</i>\OWASP ZAP</li>
-<li>Windows XP: C:\Documents and Settings\<i>&lt;username&gt;</i>\OWASP ZAP</li>
+<li>Windows 7/8: C:\Users\<i>&lt;username&gt;</i>\ZAP</li>
+<li>Windows XP: C:\Documents and Settings\<i>&lt;username&gt;</i>\ZAP</li>
 <li>Linux: ~/.ZAP</li>
 <li>Mac OS: ~/Library/Application Support/ZAP</li>
 </ul>

--- a/addOns/help/src/main/javahelp/contents/ui/tlmenu/help.html
+++ b/addOns/help/src/main/javahelp/contents/ui/tlmenu/help.html
@@ -10,7 +10,7 @@ The Help menu
 <H1>The Help menu</H1>
 This menu gives access to the 'about' dialog and this help file.
 
-<H3>About OWASP ZAP</H3>
+<H3>About ZAP</H3>
 This displayed the 'about' dialog.
 
 <H3>Support Info...</H3>
@@ -23,7 +23,7 @@ The dialog includes an "Open" button, which assuming the OS supports the necessa
 <H3>Check for Updates...</H3>
 This checks to see if you are running the latest version of ZAP.
 
-<H3>OWASP Desktop ZAP User Guide</H3>
+<H3>Desktop ZAP User Guide</H3>
 Displays this help file.
 
 <p>


### PR DESCRIPTION
Remove OWASP references in the main help files.
Update Crowdin links.
Update paths, to home dir in Windows and installation dir in macOS.