### PR TITLE
Update OWASP ZAP homepage link

### DIFF
--- a/addOns/help/CHANGELOG.md
+++ b/addOns/help/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Update OWASP ZAP homepage link in 1.1.0 release notes.
 
 ## [17] - 2023-10-12
 ### Added

--- a/addOns/help/src/main/javahelp/contents/releases/1.1.0.html
+++ b/addOns/help/src/main/javahelp/contents/releases/1.1.0.html
@@ -15,7 +15,7 @@ The following changes were made in this release:
 
 <H3>OWASP rebranding</H3>
 ZAP has been accepted as an OWASP project.<br>
-Its homepage is now: https://owasp.org/www-project-zap/
+Its homepage is now: https://wiki.owasp.org/index.php/OWASP_Zed_Attack_Proxy_Project
 
 <H3>Brute Force</H3>
 The ability to brute force files and directories based on code from the OWASP DirBuster project. <br>


### PR DESCRIPTION
Link to the wiki which still has the homepage (latest site gives 404).