### PR TITLE
Docs: Add Gnome proxy settings user guide

### DIFF
--- a/addOns/help/CHANGELOG.md
+++ b/addOns/help/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Added
 - Add Gnome proxy settings user guide
 
 ## [18] - 2024-05-07

--- a/addOns/help/CHANGELOG.md
+++ b/addOns/help/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 ### Added
-- Add Gnome proxy settings user guide
+- Details for setting Gnome proxy settings.
 
 ## [18] - 2024-05-07
 ### Added

--- a/addOns/help/CHANGELOG.md
+++ b/addOns/help/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+- Add Gnome proxy settings user guide
 
 ## [18] - 2024-05-07
 ### Added

--- a/addOns/help/src/main/javahelp/contents/start/proxies.html
+++ b/addOns/help/src/main/javahelp/contents/start/proxies.html
@@ -113,6 +113,18 @@ Ensure 'SSL Proxy' is also configured, either by selecting 'Use this proxy serve
 <tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td>Press the</td><td> Network Options 'Apply' button</td></tr>
 </table>
 
+<H3>Linux Gnome Proxy settings</H3>
+
+<table>
+<tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td>Select the</td><td> 'Gnome Settings'</td></tr>
+<tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td>Select the</td><td> 'Network:'</td></tr>
+<tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td>Enter in the</td><td> 'Proxy' in the 'Proxy' section</td></tr>
+<tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td>Press the</td><td> 'Network Proxy' toggle</td></tr>
+<tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td>Select</td><td> 'Manual' in the 'Configuration' section</td></tr>
+<tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td>Enter in the</td><td> HTTP (or HTTPs) Proxy 'URL' field the 'URL' you configured in the options screen</td></tr>
+<tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td>Enter in the</td><td> HTTP (or HTTPs) Proxy 'Port' field the 'Port' you configured in the options screen</td></tr>
+</table>
+
 <H3>Windows LAN Settings</H3>
 
 <table>

--- a/addOns/help/src/main/javahelp/contents/start/proxies.html
+++ b/addOns/help/src/main/javahelp/contents/start/proxies.html
@@ -116,11 +116,11 @@ Ensure 'SSL Proxy' is also configured, either by selecting 'Use this proxy serve
 <H3>Linux Gnome Proxy settings</H3>
 
 <table>
-<tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td>Select the</td><td> 'Gnome Settings'</td></tr>
-<tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td>Select the</td><td> 'Network:'</td></tr>
+<tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td>Press the</td><td> 'Gnome Settings' in the top corner</td></tr>
+<tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td>Select the</td><td> 'Network' item in the left</td></tr>
 <tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td>Enter in the</td><td> 'Proxy' in the 'Proxy' section</td></tr>
 <tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td>Press the</td><td> 'Network Proxy' toggle</td></tr>
-<tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td>Select</td><td> 'Manual' in the 'Configuration' section</td></tr>
+<tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td>Select</td><td> 'Manual' in the 'Configuration' dropdown</td></tr>
 <tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td>Enter in the</td><td> HTTP (or HTTPs) Proxy 'URL' field the 'URL' you configured in the options screen</td></tr>
 <tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td>Enter in the</td><td> HTTP (or HTTPs) Proxy 'Port' field the 'Port' you configured in the options screen</td></tr>
 </table>


### PR DESCRIPTION
This PR add a section in the user guide on how to configure proxy using Gnome Settings GUI.