### PR TITLE
Update extended team credits for veggiespam

### DIFF
--- a/addOns/help/src/main/javahelp/contents/credits.html
+++ b/addOns/help/src/main/javahelp/contents/credits.html
@@ -43,7 +43,7 @@ People who have made contributions to ZAP over the years, in alphabetical order:
 <tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td>Yang Bai (<a href="https://www.geekby.site/">@Geekby</a>)</td></tr>
 <tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td>Florent Baillais (<a href="https://twitter.com/flocurity">@flocurity</a>)</td></tr>
 <tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td>Adam Baldwin (<a href="https://twitter.com/adamhawkbaldwin">@adamhawkbaldwin</a>)</td></tr>
-<tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td><a href="https://www.veggiespam.com">Jay Ball</a> (<a href="https://www.linkedin.com/in/veggiespam">@veggiespam</a>, <a href="https://github.com/veggiespam">@veggiespam</a>, <a href="https://bsky.app/profile/veggiespam.bsky.social">@veggiespam.bsky.social</a>)</td></tr>
+<tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td>Jay Ball (<a href="https://www.linktr.ee/veggiespam">@veggiespam</a>)</td></tr>
 <tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td>Adrien de Beaupre</td></tr>
 <tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td>Florian Beijers (<a href="https://twitter.com/zersiax">@zersiax</a>)</td></tr>
 <tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td>Alla Bezroutchko - Gremwell</td></tr>


### PR DESCRIPTION
I'm listed in the ZAP Extended Team credits for my work on Network Exclusions and since the credits file now allows contact info, I would really appreciate it if you'd add mine. I formatted as others do it with Name linked to personal website and comma separated alternate links in parenthesis.