### PR TITLE
Update available JavaScript engine

### DIFF
--- a/addOns/help/CHANGELOG.md
+++ b/addOns/help/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Update available JavaScript engine and links.
 
 ## [20] - 2025-03-25
 ### Fixed

--- a/addOns/help/src/main/javahelp/contents/start/features/scripts.html
+++ b/addOns/help/src/main/javahelp/contents/start/features/scripts.html
@@ -12,10 +12,10 @@ Scripts
 ZAP supports scripts that can be embedded within ZAP and can access internal ZAP data structures and classes.
 These scripts allow you to dynamically enhance ZAP from within ZAP.
 <p>
-ZAP supports any scripting language that supports JSR 223 (http://www.jcp.org/en/jsr/detail?id=223) , including:
+ZAP supports any scripting language that supports <a href="https://www.jcp.org/en/jsr/detail?id=223">JSR 223</a>, including:
 <ul>
-<li>ECMAScript / JavaScript (using <a href="https://docs.oracle.com/javase/8/docs/technotes/guides/scripting/nashorn/">Nashorn engine</a>, included by default)</li>
-<li>Zest <a href="https://developer.mozilla.org/en-US/docs/zest">https://developer.mozilla.org/en-US/docs/zest</a> (included by default)</li>
+<li>ECMAScript / JavaScript (through the <a href="https://www.zaproxy.org/docs/desktop/addons/graalvm-javascript/">GraalVM JavaScript add-on</a>)</li>
+<li><a href="https://www.zaproxy.org/docs/desktop/addons/zest/">Zest</a></li>
 <li>Groovy <a href="https://groovy-lang.org/">https://groovy-lang.org/</a></li>
 <li>Kotlin <a href="https://kotlinlang.org/">https://kotlinlang.org/</a></li>
 <li>Python <a href="https://www.jython.org">https://www.jython.org</a></li>


### PR DESCRIPTION
Link to the add-on instead of Nashorn.
Also, remove mention that JavaScript/Zest are included by default, they aren't for all distributions.
Link to the Zest add-on help as the older link is a 404.