### PR TITLE
ascan.html: Add `p` tags to each appropriate paragraph

### DIFF
--- a/addOns/help/src/main/javahelp/contents/ui/dialogs/options/ascan.html
+++ b/addOns/help/src/main/javahelp/contents/ui/dialogs/options/ascan.html
@@ -10,66 +10,67 @@ Options Active Scan screen
 <H1>Options Active Scan screen</H1>
 <p>
 This screen allows you to configure the <a href="../../../start/features/ascan.html">active scan</a> options:
+</p>
 
 <H3>Number of Hosts Scanned Concurrently</H3>
-The maximum number of hosts that will be scanned at the same time.
-Increasing this may put extra strain on the computer ZAP is running on.
+<p>The maximum number of hosts that will be scanned at the same time.<br>
+Increasing this may put extra strain on the computer ZAP is running on.</p>
 
 <H3>Concurrent Scanning Threads per Host</H3>
-The number of threads the scanner will use per host.<br>
-Increasing the number of threads will speed up the scan but may put extra strain on the computer ZAP is running on and the target host.
+<p>The number of threads the scanner will use per host.<br>
+Increasing the number of threads will speed up the scan but may put extra strain on the computer ZAP is running on and the target host.</p>
 
 <H3>Max Results to List</H3>
-The number of results that will be shown in the Active Scan tab.<br>
-Displaying a large number of results can significantly increase the time a scan takes.
+<p>The number of results that will be shown in the Active Scan tab.<br>
+Displaying a large number of results can significantly increase the time a scan takes.</p>
 
 <H3>Maximum Rule Duration (minutes; 0 is unlimited)</H3>
-The maximum time any individual rule can run for in minutes. Zero means no limit. This can be used to prevent rules that are taking an excessive amount of time. 
+<p>The maximum time any individual rule can run for in minutes. Zero means no limit. This can be used to prevent rules that are taking an excessive amount of time. </p>
 
 <H3>Max alerts any rule can raise</H3>
-The maximum number of alerts any rule can raise during the active scan, scan rules that reach this value are skipped.<br>
-<strong>Note:</strong> The maximum might be exceed due to threading.
+<p>The maximum number of alerts any rule can raise during the active scan, scan rules that reach this value are skipped.<br>
+<strong>Note:</strong> The maximum might be exceed due to threading.</p>
 
 <H3>Maximum Scan Duration (minutes; 0 is unlimited)</H3>
-The maximum time that the whole scan can run for in minutes. Zero means no limit. This can be used to ensure that a scan is completed around a set time. 
+<p>The maximum time that the whole scan can run for in minutes. Zero means no limit. This can be used to ensure that a scan is completed around a set time. </p>
 
 <H3>Delay When Scanning (In Milliseconds)</H3>
-The delay in milliseconds between each request.<br>
+<p>The delay in milliseconds between each request.<br>
 Setting this to a non zero value will increase the time an active scan takes, but will put less of a strain
 on the target host.
 <br><strong>Note:</strong> This option has been deprecated and it will be removed in a future release. Use the Network &gt; Rate Limit option instead. The latter option
-allows to enforce the rate at which the requests are sent while the Delay When Scanning doesn't.
+allows to enforce the rate at which the requests are sent while the Delay When Scanning doesn't.</p>
 
 <H3>Inject plugin ID in header for all active scan requests.</H3>
-If this option is selected the active scanner will inject the request header <code>X-ZAP-Scan-ID</code> with the ID of
-the scan rule that's sending the HTTP requests.
+<p>If this option is selected the active scanner will inject the request header <code>X-ZAP-Scan-ID</code> with the ID of
+the scan rule that's sending the HTTP requests.</p>
 
 <H3>Handle anti-CSRF tokens.</H3>
-If this option is selected then the active scanner will attempt to automatically request 
+<p>If this option is selected then the active scanner will attempt to automatically request 
 <a href="../../../start/features/anticsrf.html">anti CSRF</a> tokens when required.<br>
 Previously this would have forced the scanner to only use one thread, but that is no longer the case.
 You are strongly recommended to check that the anti CSRF tokens are being correctly generated if more than one thread is being used,
-for example using custom <a href="../../../start/features/tags.html">tags</a> to check for success / failure patterns in the response.
+for example using custom <a href="../../../start/features/tags.html">tags</a> to check for success / failure patterns in the response.</p>
 
 <H3>In Attack Mode prompt to rescan nodes when scope changed.</H3>
-If this option is selected then when you select Attack <a href="../../../start/features/modes.html">mode</a> you will be prompted to choose whether to rescan nodes in scope.<br>
-If the option is not selected then the following option will control whether the nodes are rescanned.
+<p>If this option is selected then when you select Attack <a href="../../../start/features/modes.html">mode</a> you will be prompted to choose whether to rescan nodes in scope.<br>
+If the option is not selected then the following option will control whether the nodes are rescanned.</p>
 
 <H3>In Attack Mode always rescan nodes when scope changed.</H3>
-If this option is selected then when running in Attack <a href="../../../start/features/modes.html">mode</a> all nodes in scope will be rescanned if the scope changes.<br>
-This is not recommended for large sites as it could take a long time.
+<p>If this option is selected then when running in Attack <a href="../../../start/features/modes.html">mode</a> all nodes in scope will be rescanned if the scope changes.<br>
+This is not recommended for large sites as it could take a long time.</p>
 
 <H3>Default Active Scan Policy</H3>
-The <a href="../../../start/features/scanpolicy.html">Scan Policy</a> that is used by default when you start an active scan.
+<p>The <a href="../../../start/features/scanpolicy.html">Scan Policy</a> that is used by default when you start an active scan.</p>
 
 <H3>Attack Mode Scan Policy</H3>
-The <a href="../../../start/features/scanpolicy.html">Scan Policy</a> that is used for scanning in 
-Attack <a href="../../../start/features/modes.html">mode</a>.
+<p>The <a href="../../../start/features/scanpolicy.html">Scan Policy</a> that is used for scanning in 
+Attack <a href="../../../start/features/modes.html">mode</a>.</p>
 
 <H3>Max Progress Chart in Mins</H3>
-The maximum time in minutes for which response codes will be charted in the
+<p>The maximum time in minutes for which response codes will be charted in the
 <a href="../scanprogress.html">Scan Progress dialog</a>.<br>
-To disable the chart the option should be set to zero minutes.
+To disable the chart the option should be set to zero minutes.</p>
 
 <H2>See also</H2>
 <table>


### PR DESCRIPTION
Enclosed the paragraph following each `<H3>` tag in the `ui/dialogs/options/ascan.html` file with `<p>` tags, such as [`paros.html`](https://github.com/zaproxy/zap-core-help/blob/cab5bda4571eb230988c4416ffe1c9aea99cd219/addOns/help/src/main/javahelp/contents/paros.html).

This change fixes an issue where translation units were split mid-sentence, which caused problems for languages with different grammar from English, such as Japanese. Now translators can work with complete sentences for better accuracy.