### PR TITLE
Trigger Crowdin upload on English help files changes

### DIFF
--- a/.github/workflows/crowdin-upload-files.yml
+++ b/.github/workflows/crowdin-upload-files.yml
@@ -1,6 +1,11 @@
 name: Crowdin Upload Files
 
 on:
+  push:
+    branches:
+      - main
+    paths:
+      - addOns/help/src/main/javahelp/**
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
Updates workflow to run on pushes to the main branch affecting files in `addOns/help/src/main/javahelp/`.
This ensures Crowdin uploads are triggered when the English help files are modified.

Signed-off-by: Makoto Sakaguchi <ycco34vx@gmail.com>