### PR TITLE
checkforupdates.html: Wrap options dialog sections in paragraph tags

### DIFF
--- a/addOns/help/src/main/javahelp/contents/ui/dialogs/options/checkforupdates.html
+++ b/addOns/help/src/main/javahelp/contents/ui/dialogs/options/checkforupdates.html
@@ -14,52 +14,52 @@ the latest version when it starts, and if so what it does.
 </p>
 
 <H3>Check for Updates on startup</H3>
-If selected then ZAP will automatically check for updates to the whole application and all of the add-ons when it starts.<br>
+<p>If selected then ZAP will automatically check for updates to the whole application and all of the add-ons when it starts.<br>
 It is strongly recommended that you check this box.<br>
 If for any reason you choose not to then you should manually check for updates frequently.<br>
-ZAP will only make one request, and the only information included will be the current version you are on.
+ZAP will only make one request, and the only information included will be the current version you are on.</p>
 
 <H3>Automatically download new ZAP releases.</H3>
-If selected then ZAP will automatically download new ZAP releases when they are available and prompt you to install them. 
+<p>If selected then ZAP will automatically download new ZAP releases when they are available and prompt you to install them.</p>
 
 <H3>Automatically install updates to the add-ons you have installed.</H3>
-If selected then ZAP will automatically download and install any updates to the add-ons you have installed.
+<p>If selected then ZAP will automatically download and install any updates to the add-ons you have installed.</p>
 
 <H3>Automatically install updates to the scan rules you have installed.</H3>
-If selected then ZAP will automatically download and install any updates to the scan rules you have installed.<br>
-These are a subset of the full set of add-ons installed.
+<p>If selected then ZAP will automatically download and install any updates to the scan rules you have installed.<br>
+These are a subset of the full set of add-ons installed.</p>
 
 <H3>Report new Release status add-ons.</H3>
-If selected then ZAP will inform you if and when any add-ons are promoted to 'release' status.<br>
-These add-ons will have been thoroughly tested and reviewed, and you can be sure they are of the highest status.
+<p>If selected then ZAP will inform you if and when any add-ons are promoted to 'release' status.<br>
+These add-ons will have been thoroughly tested and reviewed, and you can be sure they are of the highest status.</p>
 
 <H3>Report new Beta status add-ons.</H3>
-If selected then ZAP will inform you if and when any add-ons are promoted to 'beta' status.<br>
+<p>If selected then ZAP will inform you if and when any add-ons are promoted to 'beta' status.<br>
 These add-ons will have been tested and reviewed, and are considered to be of a reasonable status 
 and mostly fit for purpose.<br>
 However they may be incomplete or need further testing.<br>
-Some of the add-ons included with ZAP by default are still at the beta level.  
+Some of the add-ons included with ZAP by default are still at the beta level.</p>
 
 <H3>Report new Alpha status add-ons.</H3>
-If selected then ZAP will inform you if and when any new add-ons are added at 'alpha' status.<br>
+<p>If selected then ZAP will inform you if and when any new add-ons are added at 'alpha' status.<br>
 These add-ons will have been reviewed but they are typically at an early stage of development.<br>
-They may be incomplete, contain significant issues or cause stability problems.
+They may be incomplete, contain significant issues or cause stability problems.</p>
 
 <H3>Add-on directories</H3>
-ZAP will load all of the add-ons from the <a href="../../../start/features/addons.html">default <code>plugin</code>
+<p>ZAP will load all of the add-ons from the <a href="../../../start/features/addons.html">default <code>plugin</code>
 directories</a>.<br>
 You can also add as many additional add-on directories as you need by adding them here.<br>
 This can be very useful when running multiple ZAP instances on one machine, for example in a CI environment.<br>
 You can then just download new or updated add-ons once and immediately share them between multiple instances.<br>
 Add-ons downloaded into shared directories will be only added to new ZAP instances, not to ones that are already running,
-with the exception of the instance that actually downloaded the add-on. 
+with the exception of the instance that actually downloaded the add-on.</p>
 
 <H3>Download directory</H3>
-This is the directory ZAP will download new or updated add-ons to.<br>
+<p>This is the directory ZAP will download new or updated add-ons to.<br>
 By default it will be the local directory, but you can also choose one of the shared directories as long as this ZAP
 instance can write to it.<br>
 ZAP will only move add-ons to a shared directory after they are completely downloaded, so that other ZAP instances
-do not try to load an incomplete add-on.
+do not try to load an incomplete add-on.</p>
 
 <H2>See also</H2>
 <table>


### PR DESCRIPTION
Updated `ui/dialogs/options/checkforupdates.html` to wrap explanatory text for each option in `<p>` tags for improved HTML structure and readability.

This change addresses an issue where translation units are split in the middle of a sentence, which caused problems for languages with grammars different from English, such as Japanese. Translators can now work with complete sentences, which should improve accuracy.